### PR TITLE
Fix: Adjust spacing for checkbox and radio fields (Closes #69)

### DIFF
--- a/priv/templates/components/checkbox_field.eex
+++ b/priv/templates/components/checkbox_field.eex
@@ -330,19 +330,19 @@ defmodule <%= @module %> do
   defp border_class(_), do: border_class("extra_small")
   <% end %>
   <%= if is_nil(@space) or "extra_small" in @space do %>
-  defp space_class("extra_small"), do: "[&_.checkbox-field-wrapper]:space-x-1"
+  defp space_class("extra_small"), do: "[&_.checkbox-field-wrapper]:gap-1"
   <% end %>
   <%= if is_nil(@space) or "small" in @space do %>
-  defp space_class("small"), do: "[&_.checkbox-field-wrapper]:space-x-1.5"
+  defp space_class("small"), do: "[&_.checkbox-field-wrapper]:gap-1.5"
   <% end %>
   <%= if is_nil(@space) or "medium" in @space do %>
-  defp space_class("medium"), do: "[&_.checkbox-field-wrapper]:space-x-2"
+  defp space_class("medium"), do: "[&_.checkbox-field-wrapper]:gap-2"
   <% end %>
   <%= if is_nil(@space) or "large" in @space do %>
-  defp space_class("large"), do: "[&_.checkbox-field-wrapper]:space-x-2.5"
+  defp space_class("large"), do: "[&_.checkbox-field-wrapper]:gap-2.5"
   <% end %>
   <%= if is_nil(@space) or "extra_large" in @space do %>
-  defp space_class("extra_large"), do: "[&_.checkbox-field-wrapper]:space-x-3"
+  defp space_class("extra_large"), do: "[&_.checkbox-field-wrapper]:gap-3"
   <% end %>
   defp space_class(params) when is_binary(params), do: params
   <%= if is_nil(@space) or "medium" in @space do %>

--- a/priv/templates/components/radio_field.eex
+++ b/priv/templates/components/radio_field.eex
@@ -284,19 +284,19 @@ defmodule <%= @module %> do
   defp border_class(_), do: border_class("extra_small")
 
   <%= if is_nil(@space) or "extra_small" in @space do %>
-  defp space_class("extra_small"), do: "[&_.radio-field-wrapper]:space-x-1"
+  defp space_class("extra_small"), do: "[&_.radio-field-wrapper]:gap-1"
   <% end %>
   <%= if is_nil(@space) or "small" in @space do %>
-  defp space_class("small"), do: "[&_.radio-field-wrapper]:space-x-1.5"
+  defp space_class("small"), do: "[&_.radio-field-wrapper]:gap-1.5"
   <% end %>
   <%= if is_nil(@space) or "medium" in @space do %>
-  defp space_class("medium"), do: "[&_.radio-field-wrapper]:space-x-2"
+  defp space_class("medium"), do: "[&_.radio-field-wrapper]:gap-2"
   <% end %>
   <%= if is_nil(@space) or "large" in @space do %>
-  defp space_class("large"), do: "[&_.radio-field-wrapper]:space-x-2.5"
+  defp space_class("large"), do: "[&_.radio-field-wrapper]:gap-2.5"
   <% end %>
   <%= if is_nil(@space) or "extra_large" in @space do %>
-  defp space_class("extra_large"), do: "[&_.radio-field-wrapper]:space-x-3"
+  defp space_class("extra_large"), do: "[&_.radio-field-wrapper]:gap-3"
   <% end %>
   defp space_class(params) when is_binary(params), do: params
   <%= if is_nil(@space) or "medium" in @space do %>


### PR DESCRIPTION
### Description
This PR addresses the alignment issue in forms by fixing the gap between the label and input fields for both checkboxes and radio buttons, applying the solution for both normal and reversed modes.

### Changes
- Adjusted gap spacing for `checkbox_field` and `radio_field`

### Issue Link
Closes #69