### PR TITLE
FIX: correct typo `separated` across the project based on #80

### DIFF
--- a/priv/templates/components/accordion.eex
+++ b/priv/templates/components/accordion.eex
@@ -31,7 +31,7 @@ defmodule <%= @module %> do
     "default",
     "contained",
     "filled",
-    "seperated",
+    "separated",
     "tinted_split",
     "transparent",
     "menu"
@@ -504,7 +504,7 @@ defmodule <%= @module %> do
     |> JS.remove_class("active-accordion-button", to: "##{id}-role-button")
   end
   <% end %>
-  defp space_class(_, variant) when variant not in ["seperated", "tinted_split"], do: nil
+  defp space_class(_, variant) when variant not in ["separated", "tinted_split"], do: nil
   <%= if is_nil(@space) or "extra_small" in @space do %>
   defp space_class("extra_small", _), do: "accordion-item-gap space-y-2"
   <% end %>
@@ -1179,9 +1179,9 @@ defmodule <%= @module %> do
   end
   <% end %>
   <% end %>
-  <%= if is_nil(@variant) or "seperated" in @variant do %>
+  <%= if is_nil(@variant) or "separated" in @variant do %>
   <%= if is_nil(@color) or "white" in @color do %>
-  defp color_variant("seperated", "white") do
+  defp color_variant("separated", "white") do
     [
       "[&>.accordion-item-wrapper]:bg-white",
       "[&>.accordion-item-wrapper]:border [&>.accordion-item-wrapper]:border-[#DADADA]"
@@ -1189,7 +1189,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "primary" in @color do %>
-  defp color_variant("seperated", "primary") do
+  defp color_variant("separated", "primary") do
     [
       "[&>.accordion-item-wrapper]:bg-white",
       "[&>.accordion-item-wrapper]:border [&>.accordion-item-wrapper]:border-[#4363EC]"
@@ -1197,7 +1197,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "secondary" in @color do %>
-  defp color_variant("seperated", "secondary") do
+  defp color_variant("separated", "secondary") do
     [
       "[&>.accordion-item-wrapper]:bg-white",
       "[&>.accordion-item-wrapper]:border [&>.accordion-item-wrapper]:border-[#6B6E7C]"
@@ -1205,7 +1205,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "success" in @color do %>
-  defp color_variant("seperated", "success") do
+  defp color_variant("separated", "success") do
     [
       "[&>.accordion-item-wrapper]:bg-white",
       "[&>.accordion-item-wrapper]:border [&>.accordion-item-wrapper]:border-[#227A52]"
@@ -1213,7 +1213,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "warning" in @color do %>
-  defp color_variant("seperated", "warning") do
+  defp color_variant("separated", "warning") do
     [
       "[&>.accordion-item-wrapper]:bg-white",
       "[&>.accordion-item-wrapper]:border [&>.accordion-item-wrapper]:border-[#FF8B08]"
@@ -1221,7 +1221,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "danger" in @color do %>
-  defp color_variant("seperated", "danger") do
+  defp color_variant("separated", "danger") do
     [
       "[&>.accordion-item-wrapper]:bg-white",
       "[&>.accordion-item-wrapper]:border [&>.accordion-item-wrapper]:border-[#E73B3B]"
@@ -1229,7 +1229,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "info" in @color do %>
-  defp color_variant("seperated", "info") do
+  defp color_variant("separated", "info") do
     [
       "[&>.accordion-item-wrapper]:bg-white",
       "[&>.accordion-item-wrapper]:border [&>.accordion-item-wrapper]:border-[#004FC4]"
@@ -1237,7 +1237,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "misc" in @color do %>
-  defp color_variant("seperated", "misc") do
+  defp color_variant("separated", "misc") do
     [
       "[&>.accordion-item-wrapper]:bg-white",
       "[&>.accordion-item-wrapper]:border [&>.accordion-item-wrapper]:border-[#52059C]"
@@ -1245,7 +1245,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "dawn" in @color do %>
-  defp color_variant("seperated", "dawn") do
+  defp color_variant("separated", "dawn") do
     [
       "[&>.accordion-item-wrapper]:bg-white",
       "[&>.accordion-item-wrapper]:border [&>.accordion-item-wrapper]:border-[#4D4137]"
@@ -1253,7 +1253,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "light" in @color do %>
-  defp color_variant("seperated", "light") do
+  defp color_variant("separated", "light") do
     [
       "[&>.accordion-item-wrapper]:bg-white",
       "[&>.accordion-item-wrapper]:border [&>.accordion-item-wrapper]:border-[#707483]"
@@ -1261,7 +1261,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "dark" in @color do %>
-  defp color_variant("seperated", "dark") do
+  defp color_variant("separated", "dark") do
     [
       "[&>.accordion-item-wrapper]:bg-white",
       "[&>.accordion-item-wrapper]:border [&>.accordion-item-wrapper]:border-[#1E1E1E]"
@@ -1664,79 +1664,79 @@ defmodule <%= @module %> do
   end
   <% end %>
   <% end %>
-  <%= if is_nil(@variant) or "seperated" in @variant do %>
+  <%= if is_nil(@variant) or "separated" in @variant do %>
   <%= if is_nil(@color) or "white" in @color do %>
-  defp item_color("seperated", "white") do
+  defp item_color("separated", "white") do
     [
       "group-open:bg-white"
     ]
   end
   <% end %>
   <%= if is_nil(@color) or "primary" in @color do %>
-  defp item_color("seperated", "primary") do
+  defp item_color("separated", "primary") do
     [
       "group-open:bg-white"
     ]
   end
   <% end %>
   <%= if is_nil(@color) or "secondary" in @color do %>
-  defp item_color("seperated", "secondary") do
+  defp item_color("separated", "secondary") do
     [
       "group-open:bg-white"
     ]
   end
   <% end %>
   <%= if is_nil(@color) or "success" in @color do %>
-  defp item_color("seperated", "success") do
+  defp item_color("separated", "success") do
     [
       "group-open:bg-white"
     ]
   end
   <% end %>
   <%= if is_nil(@color) or "warning" in @color do %>
-  defp item_color("seperated", "warning") do
+  defp item_color("separated", "warning") do
     [
       "group-open:bg-white"
     ]
   end
   <% end %>
   <%= if is_nil(@color) or "danger" in @color do %>
-  defp item_color("seperated", "danger") do
+  defp item_color("separated", "danger") do
     [
       "group-open:bg-white"
     ]
   end
   <% end %>
   <%= if is_nil(@color) or "info" in @color do %>
-  defp item_color("seperated", "info") do
+  defp item_color("separated", "info") do
     [
       "group-open:bg-white"
     ]
   end
   <% end %>
   <%= if is_nil(@color) or "misc" in @color do %>
-  defp item_color("seperated", "misc") do
+  defp item_color("separated", "misc") do
     [
       "group-open:bg-white"
     ]
   end
   <% end %>
   <%= if is_nil(@color) or "dawn" in @color do %>
-  defp item_color("seperated", "dawn") do
+  defp item_color("separated", "dawn") do
     [
       "group-open:bg-white"
     ]
   end
   <% end %>
   <%= if is_nil(@color) or "light" in @color do %>
-  defp item_color("seperated", "light") do
+  defp item_color("separated", "light") do
     [
       "group-open:bg-white"
     ]
   end
   <% end %>
   <%= if is_nil(@color) or "dark" in @color do %>
-  defp item_color("seperated", "dark") do
+  defp item_color("separated", "dark") do
     [
       "group-open:bg-white"
     ]

--- a/priv/templates/components/accordion.exs
+++ b/priv/templates/components/accordion.exs
@@ -6,7 +6,7 @@
         "default",
         "contained",
         "filled",
-        "seperated",
+        "separated",
         "tinted_split",
         "transparent",
         "menu"

--- a/priv/templates/components/list.eex
+++ b/priv/templates/components/list.eex
@@ -8,7 +8,7 @@ defmodule <%= @module %> do
   ### Features
 
   - **Styling Variants:** The component offers multiple variants like `default`,
-  `filled`, `outline`, `seperated`, `tinted_split`, and `transparent` to meet diverse design requirements.
+  `filled`, `outline`, `separated`, `tinted_split`, and `transparent` to meet diverse design requirements.
   - **Color Customization:** Choose from a variety of colors to style the list according to
   your application's theme.
   - **Flexible Layouts:** Control the size, spacing, and appearance of list items with extensive
@@ -27,7 +27,7 @@ defmodule <%= @module %> do
     "default",
     "filled",
     "outline",
-    "seperated",
+    "separated",
     "tinted_split",
     "transparent"
   ]
@@ -316,7 +316,7 @@ defmodule <%= @module %> do
   ## Examples
 
   ```elixir
-  <.list_group variant="seperated" rounded="extra_small" color="dawn">
+  <.list_group variant="separated" rounded="extra_small" color="dawn">
     <.li position="end" icon="hero-chat-bubble-left-ellipsis">HBase</.li>
     <.li>PSQL</.li>
     <.li>Sqlight</.li>
@@ -403,7 +403,7 @@ defmodule <%= @module %> do
 
   defp content_position(_), do: content_position("start")
 
-  defp border_class(_, variant) when variant in ["seperated", "tinted_split"], do: "border-0"
+  defp border_class(_, variant) when variant in ["separated", "tinted_split"], do: "border-0"
   <%= if is_nil(@size) or "extra_small" in @size do %>
   defp border_class("extra_small", _), do: "border"
   <% end %>
@@ -453,7 +453,7 @@ defmodule <%= @module %> do
     do: "[&:not(.list-items-gap)]:rounded-none [&.list-items-gap>li]:rounded-none"
   <% end %>
 
-  defp variant_space(_, variant) when variant not in ["seperated", "tinted_split"], do: nil
+  defp variant_space(_, variant) when variant not in ["separated", "tinted_split"], do: nil
   <%= if is_nil(@space) or "extra_small" in @space do %>
   defp variant_space("extra_small", _), do: "list-items-gap space-y-2"
   <% end %>
@@ -913,9 +913,9 @@ defmodule <%= @module %> do
   end
   <% end %>
   <% end %>
-  <%= if is_nil(@variant) or "seperated" in @variant do %>
+  <%= if is_nil(@variant) or "separated" in @variant do %>
   <%= if is_nil(@color) or "white" in @color do %>
-  defp color_variant("seperated", "white") do
+  defp color_variant("separated", "white") do
     [
       "[&>li]:bg-white text-[#3E3E3E]",
       "[&>li]:border [&>li]:border-[#DADADA]"
@@ -923,7 +923,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "primary" in @color do %>
-  defp color_variant("seperated", "primary") do
+  defp color_variant("separated", "primary") do
     [
       "[&>li]:bg-white text-[#2441de]",
       "[&>li]:border [&>li]:border-[#2441de]"
@@ -931,7 +931,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "secondary" in @color do %>
-  defp color_variant("seperated", "secondary") do
+  defp color_variant("separated", "secondary") do
     [
       "[&>li]:bg-white text-[#877C7C]",
       "[&>li]:border [&>li]:border-[#877C7C]"
@@ -939,7 +939,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "success" in @color do %>
-  defp color_variant("seperated", "success") do
+  defp color_variant("separated", "success") do
     [
       "[&>li]:bg-white text-[#227A52]",
       "[&>li]:border [&>li]:border-[#227A52]"
@@ -947,7 +947,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "warning" in @color do %>
-  defp color_variant("seperated", "warning") do
+  defp color_variant("separated", "warning") do
     [
       "[&>li]:bg-white text-[#FF8B08]",
       "[&>li]:border [&>li]:border-[#FF8B08]"
@@ -955,7 +955,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "danger" in @color do %>
-  defp color_variant("seperated", "danger") do
+  defp color_variant("separated", "danger") do
     [
       "[&>li]:bg-white text-[#E73B3B]",
       "[&>li]:border [&>li]:border-[#E73B3B]"
@@ -963,7 +963,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "info" in @color do %>
-  defp color_variant("seperated", "info") do
+  defp color_variant("separated", "info") do
     [
       "[&>li]:bg-white text-[#004FC4]",
       "[&>li]:border [&>li]:border-[#004FC4]"
@@ -971,7 +971,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "misc" in @color do %>
-  defp color_variant("seperated", "misc") do
+  defp color_variant("separated", "misc") do
     [
       "[&>li]:bg-white text-[#52059C]",
       "[&>li]:border [&>li]:border-[#52059C]"
@@ -979,7 +979,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "dawn" in @color do %>
-  defp color_variant("seperated", "dawn") do
+  defp color_variant("separated", "dawn") do
     [
       "[&>li]:bg-white text-[#4D4137]",
       "[&>li]:border [&>li]:border-[#4D4137]"
@@ -987,7 +987,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "light" in @color do %>
-  defp color_variant("seperated", "light") do
+  defp color_variant("separated", "light") do
     [
       "[&>li]:bg-white text-[#707483]",
       "[&>li]:border [&>li]:border-[#707483]"
@@ -995,7 +995,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@color) or "dark" in @color do %>
-  defp color_variant("seperated", "dark") do
+  defp color_variant("separated", "dark") do
     [
       "[&>li]:bg-white text-[#1E1E1E]",
       "[&>li]:border [&>li]:border-[#1E1E1E]"

--- a/priv/templates/components/list.exs
+++ b/priv/templates/components/list.exs
@@ -2,7 +2,7 @@
   list: [
     name: "list",
     args: [
-      variant: ["default", "filled", "outline", "seperated", "tinted_split", "transparent"],
+      variant: ["default", "filled", "outline", "separated", "tinted_split", "transparent"],
       color: [
         "white",
         "primary",


### PR DESCRIPTION
**Description:**

This PR corrects the minor typo of separated in variant names across several components to enhance readability and maintain consistency. These changes ensure uniformity in naming conventions across the project. No functional behavior is affected; updates are strictly limited to variant name adjustments.