### PR TITLE
Feat: add `gradient` and `bordered` variants to badge

### DIFF
--- a/priv/templates/components/badge.eex
+++ b/priv/templates/components/badge.eex
@@ -18,9 +18,11 @@ defmodule <%= @module %> do
   alias Phoenix.LiveView.JS
 
   @sizes ["extra_small", "small", "medium", "large", "extra_large"]
-  @variants ["default", "outline", "transparent", "shadow"]
+  @variants ["default", "outline", "transparent", "shadow", "bordered", "gradient"]
   @colors [
     "natural",
+    "white",
+    "dark",
     "primary",
     "secondary",
     "success",
@@ -135,7 +137,7 @@ defmodule <%= @module %> do
       <.badge_dismiss :if={dismiss_position(@rest) == "left"} id={@id} params={@params} />
       <.badge_indicator position="left" size={@indicator_size} class={@indicator_class} {@rest} />
       <.icon :if={icon_position(@icon, @rest) == "left"} name={@icon} />
-      <div><%%= render_slot(@inner_block) %></div>
+      <span class="leading-5"><%%= render_slot(@inner_block) %></span>
       <.icon :if={icon_position(@icon, @rest) == "right"} name={@icon} />
       <.badge_indicator size={@indicator_size} class={@indicator_class} {@rest} />
       <.badge_dismiss :if={dismiss_position(@rest) == "right"} id={@id} params={@params} />
@@ -284,6 +286,16 @@ defmodule <%= @module %> do
     """
   end
   <%= if is_nil(@variant) or "default" in @variant do %>
+  <%= if is_nil(@color) or "white" in @color do %>
+  defp color_variant("default", "white") do
+    ["bg-white text-black [&>.indicator]:bg-black"]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "dark" in @color do %>
+  defp color_variant("default", "dark") do
+    ["bg-[#282828] text-white [&>.indicator]:bg-white"]
+  end
+  <% end %>
   <%= if is_nil(@color) or "natural" in @color do %>
   defp color_variant("default", "natural") do
     [
@@ -641,6 +653,201 @@ defmodule <%= @module %> do
   end
   <% end %>
   <% end %>
+  <%= if is_nil(@variant) or "bordered" in @variant do %>
+  <%= if is_nil(@color) or "natural" in @color do %>
+  defp color_variant("bordered", "white") do
+    ["bg-white text-black border-[#DDDDDD] [&>.indicator]:bg-black"]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "natural" in @color do %>
+  defp color_variant("bordered", "dark") do
+    ["bg-[#282828] text-white border-[#727272] [&>.indicator]:bg-white"]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "natural" in @color do %>
+  defp color_variant("bordered", "natural") do
+    [
+      "text-[#282828] border-[#282828] bg-[#F3F3F3]",
+      "dark:text-[#E8E8E8] dark:border-[#E8E8E8] dark:bg-[#4B4B4B]",
+      "[&>.indicator]:bg-black dark:[&>.indicator]:bg-white",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "primary" in @color do %>
+  defp color_variant("bordered", "primary") do
+    [
+      "text-[#016974] border-[#016974] bg-[#E2F8FB]",
+      "dark:text-[#77D5E3] dark:border-[#77D5E3] dark:bg-[#002D33]",
+      "[&>.indicator]:bg-[#1A535A] dark:[&>.indicator]:bg-[#B0E7EF]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "secondary" in @color do %>
+  defp color_variant("bordered", "secondary") do
+    [
+      "text-[#175BCC] border-[#175BCC] bg-[#EFF4FE]",
+      "dark:text-[#A9C9FF] dark:border-[#A9C9FF] dark:bg-[#002661]",
+      "[&>.indicator]:bg-[#1948A3] dark:[&>.indicator]:bg-[#CDDEFF]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "success" in @color do %>
+  defp color_variant("bordered", "success") do
+    [
+      "text-[#166C3B] border-[#166C3B] bg-[#EAF6ED]",
+      "dark:text-[#7FD99A] dark:border-[#7FD99A] dark:bg-[#002F14]",
+      "[&>.indicator]:bg-[#0D572D] dark:[&>.indicator]:bg-[#B1EAC2]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "warning" in @color do %>
+  defp color_variant("bordered", "warning") do
+    [
+      "text-[#976A01] border-[#976A01] bg-[#FFF7E6]",
+      "dark:text-[#FDD067] dark:border-[#FDD067] dark:bg-[#322300]",
+      "[&>.indicator]:bg-[#654600] dark:[&>.indicator]:bg-[#FEDF99]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "danger" in @color do %>
+  defp color_variant("bordered", "danger") do
+    [
+      "text-[#BB032A] border-[#BB032A] bg-[#FFF0EE]",
+      "dark:text-[#FFB2AB] dark:border-[#FFB2AB] dark:bg-[#520810]",
+      "[&>.indicator]:bg-[#950F22] dark:[&>.indicator]:bg-[#FFD2CD]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "info" in @color do %>
+  defp color_variant("bordered", "info") do
+    [
+      "text-[#0B84BA] border-[#0B84BA] bg-[#E7F6FD]",
+      "dark:text-[#6EC9F2] dark:border-[#6EC9F2] dark:bg-[#03212F]",
+      "[&>.indicator]:bg-[#06425D] dark:[&>.indicator]:bg-[#9FDBF6]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "misc" in @color do %>
+  defp color_variant("bordered", "misc") do
+    [
+      "text-[#653C94] border-[#653C94] bg-[#F6F0FE]",
+      "dark:text-[#CBA2FA] dark:border-[#CBA2FA] dark:bg-[#221431]",
+      "[&>.indicator]:bg-[#442863] dark:[&>.indicator]:bg-[#DDC1FC]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "dawn" in @color do %>
+  defp color_variant("bordered", "dawn") do
+    [
+      "text-[#7E4B2A] border-[#7E4B2A] bg-[#FBF2ED]",
+      "dark:text-[#E4B190] dark:border-[#E4B190] dark:bg-[#2A190E]",
+      "[&>.indicator]:bg-[#54321C] dark:[&>.indicator]:bg-[#EDCBB5]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "silver" in @color do %>
+  defp color_variant("bordered", "silver") do
+    [
+      "text-[#727272] border-[#727272] bg-[#F3F3F3]",
+      "dark:text-[#BBBBBB] dark:border-[#BBBBBB] dark:bg-[#4B4B4B]",
+      "[&>.indicator]:bg-[#5E5E5E] dark:[&>.indicator]:bg-[#DDDDDD]",
+    ]
+  end
+  <% end %>
+  <% end %>
+  <%= if is_nil(@variant) or "gradient" in @variant do %>
+  <%= if is_nil(@color) or "natural" in @color do %>
+  defp color_variant("gradient", "natural") do
+    [
+      "bg-gradient-to-br from-[#282828] to-[#727272] text-white",
+      "dark:from-[#A6A6A6] dark:to-[#FFFFFF] dark:text-black",
+      "[&>.indicator]:bg-white dark:[&>.indicator]:bg-black",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "primary" in @color do %>
+  defp color_variant("gradient", "primary") do
+    [
+      "bg-gradient-to-br from-[#016974] to-[#01B8CA] text-white",
+      "dark:from-[#01B8CA] dark:to-[#B0E7EF] dark:text-black",
+      "[&>.indicator]:bg-[#1A535A] dark:[&>.indicator]:bg-[#CDEEF3]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "secondary" in @color do %>
+  defp color_variant("gradient", "secondary") do
+    [
+      "bg-gradient-to-br from-[#175BCC] to-[#6DAAFB] text-white",
+      "dark:from-[#6DAAFB] dark:to-[#CDDEFF] dark:text-black",
+      "[&>.indicator]:bg-[#1948A3] dark:[&>.indicator]:bg-[#DEE9FE]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "success" in @color do %>
+  defp color_variant("gradient", "success") do
+    [
+      "bg-gradient-to-br from-[#166C3B] to-[#06C167] text-white",
+      "dark:from-[#06C167] dark:to-[#B1EAC2] dark:text-black",
+      "[&>.indicator]:bg-[#0D572D] dark:[&>.indicator]:bg-[#D3EFDA]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "warning" in @color do %>
+  defp color_variant("gradient", "warning") do
+    [
+      "bg-gradient-to-br from-[#976A01] to-[#FDC034] text-white",
+      "dark:from-[#FDC034] dark:to-[#FEDF99] dark:text-black",
+      "[&>.indicator]:bg-[#654600] dark:[&>.indicator]:bg-[#FEEFCC]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "danger" in @color do %>
+  defp color_variant("gradient", "danger") do
+    [
+      "bg-gradient-to-br from-[#BB032A] to-[#FC7F79] text-white",
+      "dark:from-[#FC7F79] dark:to-[#FFD2CD] dark:text-black",
+      "[&>.indicator]:bg-[#950F22] dark:[&>.indicator]:bg-[#FFE1DE]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "info" in @color do %>
+  defp color_variant("gradient", "info") do
+    [
+      "bg-gradient-to-br from-[#08638C] to-[#3EB7ED] text-white",
+      "dark:from-[#3EB7ED] dark:to-[#9FDBF6] dark:text-black",
+      "[&>.indicator]:bg-[#06425D] dark:[&>.indicator]:bg-[#CFEDFB]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "misc" in @color do %>
+  defp color_variant("gradient", "misc") do
+   [
+      "bg-gradient-to-br from-[#653C94] to-[#BA83F9] text-white",
+      "dark:from-[#BA83F9] dark:to-[#DDC1FC] dark:text-black",
+      "[&>.indicator]:bg-[#442863] dark:[&>.indicator]:bg-[#EEE0FD]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "dawn" in @color do %>
+  defp color_variant("gradient", "dawn") do
+    [
+      "bg-gradient-to-br from-[#7E4B2A] to-[#DB976B] text-white",
+      "dark:from-[#DB976B] dark:to-[#EDCBB5] dark:text-black",
+      "[&>.indicator]:bg-[#54321C] dark:[&>.indicator]:bg-[#F6E5DA]",
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "silver" in @color do %>
+  defp color_variant("gradient", "silver") do
+    [
+      "bg-gradient-to-br from-[#5E5E5E] to-[#A6A6A6] text-white",
+      "dark:from-[#868686] dark:to-[#BBBBBB] dark:text-black",
+      "[&>.indicator]:bg-[#4B4B4B] dark:[&>.indicator]:bg-[#E8E8E8]",
+    ]
+  end
+  <% end %>
+  <% end %>
+  defp color_variant(params, _) when is_binary(params), do: params
   <%= if is_nil(@variant) or "default" in @variant do %>
   <%= if is_nil(@color) or "natural" in @color do %>
   defp color_variant(_, _), do: color_variant("default", "natural")
@@ -668,7 +875,7 @@ defmodule <%= @module %> do
   defp rounded_size("none"), do: nil
   <% end %>
 
-  defp border_size(_, variant) when variant in ["default", "shadow", "transparent"], do: nil
+  defp border_size(_, variant) when variant in ["default", "shadow", "transparent", "gradient"], do: nil
   defp border_size("none",_), do: nil
   defp border_size("extra_small",_), do: "border"
   defp border_size("small",_), do: "border-2"

--- a/priv/templates/components/badge.exs
+++ b/priv/templates/components/badge.exs
@@ -2,9 +2,11 @@
   badge: [
     name: "badge",
     args: [
-      variant: ["default", "outline", "transparent", "shadow"],
+      variant: ["default", "outline", "transparent", "shadow", "bordered", "gradient"],
       color: [
         "natural",
+        "white",
+        "dark",
         "primary",
         "secondary",
         "success",


### PR DESCRIPTION
**Summary**

- Add `gradient` and `bordered` variants
- Add `white` and `dark` colors to `default` and bordered variants