### PR TITLE
Feat: Add `gradient` and `borderd` variants of `popover`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add dark mode of dropdown component [#104](https://github.com/mishka-group/mishka_chelekom/pull/104)
 - Add dark mode of Overlay component [#106](https://github.com/mishka-group/mishka_chelekom/pull/106)
 - Add dark mode of Card component [#107](https://github.com/mishka-group/mishka_chelekom/pull/107)
+- Add dark mode and add `show_arrow` prop of Popover component [#121](https://github.com/mishka-group/mishka_chelekom/pull/121)
 
 ### Bugs:
 - Fix un-CSP progress mounted [#72](https://github.com/mishka-group/mishka_chelekom/pull/72)

--- a/priv/templates/components/popover.eex
+++ b/priv/templates/components/popover.eex
@@ -262,7 +262,7 @@ defmodule <%= @module %> do
   attr :variant, :string, values: @variants, default: "shadow", doc: "Determines the style"
   attr :color, :string, values: @colors, default: "natural", doc: "Determines color theme"
   attr :rounded, :string, default: nil, doc: "Determines the border radius"
-  attr :show_arrow, :boolean, default: true, doc: "Determines the border radius"
+  attr :show_arrow, :boolean, default: true, doc: "Show or hide arrow of popover"
   attr :border, :string, default: "extra_small", doc: "Determines border style"
 
   attr :size, :string,
@@ -346,6 +346,21 @@ defmodule <%= @module %> do
 
   defp tirgger_popover(),
     do: "[&_.popover-content]:hover:visible [&_.popover-content]:hover:opacity-100"
+
+
+  defp border_class("extra_small"), do: "border"
+
+  defp border_class("small"), do: "border-2"
+
+  defp border_class("medium"), do: "border-[3px]"
+
+  defp border_class("large"), do: "border-4"
+
+  defp border_class("extra_large"), do: "border-[5px]"
+
+  defp border_class(params) when is_binary(params), do: params
+
+  defp border_class(_), do: border_class("extra_small")
 
   <%= if is_nil(@rounded) or "extra_small" in @rounded do %>
   defp rounded_size("extra_small"), do: "rounded-sm"

--- a/priv/templates/components/popover.eex
+++ b/priv/templates/components/popover.eex
@@ -18,23 +18,26 @@ defmodule <%= @module %> do
   use Phoenix.Component
   alias Phoenix.LiveView.JS
 
-  @colors [
-    "white",
+   @colors [
+    "natural",
     "primary",
     "secondary",
-    "dark",
     "success",
     "warning",
     "danger",
     "info",
-    "light",
+    "silver",
     "misc",
+    "dark",
+    "white",
     "dawn"
   ]
 
   @variants [
     "default",
-    "shadow"
+    "shadow",
+    "bordered",
+    "gradient"
   ]
   <%= if is_nil(@type) or "popover" in @type do %>
   @doc """
@@ -257,8 +260,10 @@ defmodule <%= @module %> do
   attr :inline, :boolean, default: false, doc: "Determines whether this element is inline"
   attr :position, :string, default: "top", doc: "Determines the element position"
   attr :variant, :string, values: @variants, default: "shadow", doc: "Determines the style"
-  attr :color, :string, values: @colors, default: "white", doc: "Determines color theme"
+  attr :color, :string, values: @colors, default: "natural", doc: "Determines color theme"
   attr :rounded, :string, default: nil, doc: "Determines the border radius"
+  attr :show_arrow, :boolean, default: true, doc: "Determines the border radius"
+  attr :border, :string, default: "extra_small", doc: "Determines border style"
 
   attr :size, :string,
     default: nil,
@@ -296,6 +301,7 @@ defmodule <%= @module %> do
         size_class(@size),
         position_class(@position),
         text_position(@text_position),
+        @variant == "bordered" && border_class(@border),
         width_class(@width),
         wrapper_padding(@padding),
         @font_weight,
@@ -304,7 +310,7 @@ defmodule <%= @module %> do
       {@rest}
     >
       <%%= render_slot(@inner_block) %>
-      <span class={["block absolute size-[8px] bg-inherit rotate-45 popover-arrow"]}></span>
+      <span :if={@show_arrow && @variant != "bordered"} class={["block absolute size-[8px] bg-inherit rotate-45 popover-arrow"]}></span>
     </span>
     """
   end
@@ -323,6 +329,7 @@ defmodule <%= @module %> do
         size_class(@size),
         position_class(@position),
         text_position(@text_position),
+        @variant == "bordered" && border_class(@border),
         width_class(@width),
         wrapper_padding(@padding),
         @font_weight,
@@ -331,10 +338,7 @@ defmodule <%= @module %> do
       {@rest}
     >
       <%%= render_slot(@inner_block) %>
-      <span class={[
-        "block absolute size-[8px] bg-inherit rotate-45 popover-arrow"
-      ]}>
-      </span>
+      <span :if={@show_arrow && @variant != "bordered"} class={["block absolute size-[8px] bg-inherit rotate-45 popover-arrow"]}></span>
     </div>
     """
   end
@@ -459,7 +463,7 @@ defmodule <%= @module %> do
   end
   <% end %>
   <%= if is_nil(@padding) or "none" in @padding do %>
-  defp wrapper_padding("none"), do: "p-0"
+  defp wrapper_padding("none"), do: nil
   <% end %>
   defp wrapper_padding(params) when is_binary(params), do: params
   <%= if is_nil(@padding) or "none" in @padding do %>
@@ -482,120 +486,354 @@ defmodule <%= @module %> do
   defp space_class("extra_large"), do: "space-y-6"
   <% end %>
   defp space_class(params) when is_binary(params), do: params
-  defp space_class(_), do: "space-y-0"
+  defp space_class(_), do: nil
 
   <%= if is_nil(@variant) or "default" in @variant do %>
   <%= if is_nil(@color) or "white" in @color do %>
   defp color_variant("default", "white") do
-    "bg-white text-[#3E3E3E]"
-  end
-  <% end %>
-  <%= if is_nil(@color) or "primary" in @color do %>
-  defp color_variant("default", "primary") do
-    "bg-[#4363EC] text-white"
-  end
-  <% end %>
-  <%= if is_nil(@color) or "secondary" in @color do %>
-  defp color_variant("default", "secondary") do
-    "bg-[#6B6E7C] text-white"
-  end
-  <% end %>
-  <%= if is_nil(@color) or "success" in @color do %>
-  defp color_variant("default", "success") do
-    "bg-[#ECFEF3] text-[#047857]"
-  end
-  <% end %>
-  <%= if is_nil(@color) or "warning" in @color do %>
-  defp color_variant("default", "warning") do
-    "bg-[#FFF8E6] text-[#FF8B08]"
-  end
-  <% end %>
-  <%= if is_nil(@color) or "danger" in @color do %>
-  defp color_variant("default", "danger") do
-    "bg-[#FFE6E6] text-[#E73B3B]"
-  end
-  <% end %>
-  <%= if is_nil(@color) or "info" in @color do %>
-  defp color_variant("default", "info") do
-    "bg-[#E5F0FF] text-[#004FC4]"
-  end
-  <% end %>
-  <%= if is_nil(@color) or "misc" in @color do %>
-  defp color_variant("default", "misc") do
-    "bg-[#FFE6FF] text-[#52059C]"
-  end
-  <% end %>
-  <%= if is_nil(@color) or "dawn" in @color do %>
-  defp color_variant("default", "dawn") do
-    "bg-[#FFECDA] text-[#4D4137]"
-  end
-  <% end %>
-  <%= if is_nil(@color) or "light" in @color do %>
-  defp color_variant("default", "light") do
-    "bg-[#E3E7F1] text-[#707483]"
+    ["bg-white text-black"]
   end
   <% end %>
   <%= if is_nil(@color) or "dark" in @color do %>
   defp color_variant("default", "dark") do
-    "bg-[#1E1E1E] text-white"
+    ["bg-[#282828] text-white"]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "natural" in @color do %>
+  defp color_variant("default", "natural") do
+    [
+      "bg-[#4B4B4B] text-white dark:bg-[#DDDDDD] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "primary" in @color do %>
+  defp color_variant("default", "primary") do
+    [
+      "bg-[#007F8C] text-white dark:bg-[#01B8CA] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "secondary" in @color do %>
+  defp color_variant("default", "secondary") do
+    [
+      "bg-[#266EF1] text-white dark:bg-[#6DAAFB] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "success" in @color do %>
+  defp color_variant("default", "success") do
+    [
+      "bg-[#0E8345] text-white dark:bg-[#06C167] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "warning" in @color do %>
+  defp color_variant("default", "warning") do
+    [
+      "bg-[#CA8D01] text-white dark:bg-[#FDC034] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "danger" in @color do %>
+  defp color_variant("default", "danger") do
+    [
+      "bg-[#DE1135] text-white dark:bg-[#FC7F79] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "info" in @color do %>
+  defp color_variant("default", "info") do
+    [
+      "bg-[#0B84BA] text-white dark:bg-[#3EB7ED] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "misc" in @color do %>
+  defp color_variant("default", "misc") do
+    [
+      "bg-[#8750C5] text-white dark:bg-[#BA83F9] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "dawn" in @color do %>
+  defp color_variant("default", "dawn") do
+    [
+      "bg-[#A86438] text-white dark:bg-[#DB976B] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "silver" in @color do %>
+  defp color_variant("default", "silver") do
+     [
+      "bg-[#868686] text-white dark:bg-[#A6A6A6] dark:text-black"
+    ]
   end
   <% end %>
   <% end %>
   <%= if is_nil(@variant) or "shadow" in @variant do %>
-  <%= if is_nil(@color) or "white" in @color do %>
-  defp color_variant("shadow", "white") do
-    "bg-white text-[#3E3E3E] shadow-md"
+  <%= if is_nil(@color) or "natural" in @color do %>
+  defp color_variant("shadow", "natural") do
+    [
+      "bg-[#4B4B4B] text-white dark:bg-[#DDDDDD] dark:text-black",
+      "shadow-[0px_4px_6px_-4px_rgba(134,134,134,0.5)] shadow-[0px_10px_15px_-3px_rgba(134,134,134,0.5)] dark:shadow-none"
+    ]
   end
   <% end %>
   <%= if is_nil(@color) or "primary" in @color do %>
   defp color_variant("shadow", "primary") do
-    "bg-[#4363EC] text-white shadow-md"
+    [
+      "bg-[#007F8C] text-white dark:bg-[#01B8CA] dark:text-black",
+      "shadow-[0px_4px_6px_-4px_rgba(0,149,164,0.5)] shadow-[0px_10px_15px_-3px_rgba(0,149,164,0.5)] dark:shadow-none"
+    ]
   end
   <% end %>
   <%= if is_nil(@color) or "secondary" in @color do %>
   defp color_variant("shadow", "secondary") do
-    "bg-[#6B6E7C] text-white shadow-md"
+    [
+      "bg-[#266EF1] text-white dark:bg-[#6DAAFB] dark:text-black",
+      "shadow-[0px_4px_6px_-4px_rgba(6,139,238,0.5)] shadow-[0px_10px_15px_-3px_rgba(6,139,238,0.5)] dark:shadow-none"
+    ]
   end
   <% end %>
   <%= if is_nil(@color) or "success" in @color do %>
   defp color_variant("shadow", "success") do
-    "bg-[#AFEAD0] text-[#227A52] shadow-md"
+    [
+      "bg-[#0E8345] text-white hover:bg-[#166C3B] dark:bg-[#06C167] dark:text-black",
+      "shadow-[0px_4px_6px_-4px_rgba(0,154,81,0.5)] shadow-[0px_10px_15px_-3px_rgba(0,154,81,0.5)] dark:shadow-none"
+    ]
   end
   <% end %>
   <%= if is_nil(@color) or "warning" in @color do %>
   defp color_variant("shadow", "warning") do
-    "bg-[#FFF8E6] text-[#FF8B08] shadow-md"
+     [
+      "bg-[#CA8D01] text-white dark:bg-[#FDC034] dark:text-black",
+      "shadow-[0px_4px_6px_-4px_rgba(252,176,1,0.5)] shadow-[0px_10px_15px_-3px_rgba(252,176,1,0.5)] dark:shadow-none"
+    ]
   end
   <% end %>
   <%= if is_nil(@color) or "danger" in @color do %>
   defp color_variant("shadow", "danger") do
-    "bg-[#FFE6E6] text-[#E73B3B] shadow-md"
+    [
+      "bg-[#DE1135] text-white dark:bg-[#FC7F79] dark:text-black",
+      "shadow-[0px_4px_6px_-4px_rgba(248,52,70,0.5)] shadow-[0px_10px_15px_-3px_rgba(248,52,70,0.5)] dark:shadow-none"
+    ]
   end
   <% end %>
   <%= if is_nil(@color) or "info" in @color do %>
   defp color_variant("shadow", "info") do
-    "bg-[#E5F0FF] text-[#004FC4] shadow-md"
+    [
+      "bg-[#0B84BA] text-white dark:bg-[#3EB7ED] dark:text-black",
+      "shadow-[0px_4px_6px_-4px_rgba(14,165,233,0.5)] shadow-[0px_10px_15px_-3px_rgba(14,165,233,0.5)] dark:shadow-none"
+    ]
   end
   <% end %>
   <%= if is_nil(@color) or "misc" in @color do %>
   defp color_variant("shadow", "misc") do
-    "bg-[#FFE6FF] text-[#52059C] shadow-md"
+    [
+      "bg-[#8750C5] text-white dark:bg-[#BA83F9] dark:text-black",
+      "shadow-[0px_4px_6px_-4px_rgba(169,100,247,0.5)] shadow-[0px_10px_15px_-3px_rgba(169,100,247,0.5)] dark:shadow-none"
+    ]
   end
   <% end %>
   <%= if is_nil(@color) or "dawn" in @color do %>
   defp color_variant("shadow", "dawn") do
-    "bg-[#FFECDA] text-[#4D4137] shadow-md"
+    [
+      "bg-[#A86438] text-white dark:bg-[#DB976B] dark:text-black",
+      "shadow-[0px_4px_6px_-4px_rgba(210,125,70,0.5)] shadow-[0px_10px_15px_-3px_rgba(210,125,70,0.5)] dark:shadow-none"
+    ]
   end
   <% end %>
-  <%= if is_nil(@color) or "light" in @color do %>
-  defp color_variant("shadow", "light") do
-    "bg-[#E3E7F1] text-[#707483] shadow-md"
+  <%= if is_nil(@color) or "silver" in @color do %>
+  defp color_variant("shadow", "silver") do
+    [
+      "bg-[#868686] text-white dark:bg-[#A6A6A6] dark:text-black",
+      "shadow-[0px_4px_6px_-4px_rgba(134,134,134,0.5)] shadow-[0px_10px_15px_-3px_rgba(134,134,134,0.5)] dark:shadow-none"
+    ]
+  end
+  <% end %>
+  <% end %>
+  <%= if is_nil(@variant) or "bordered" in @variant do %>
+  <%= if is_nil(@color) or "white" in @color do %>
+  defp color_variant("bordered", "white") do
+    [
+      "bg-white text-black border-[#DDDDDD]"
+    ]
   end
   <% end %>
   <%= if is_nil(@color) or "dark" in @color do %>
-  defp color_variant("shadow", "dark") do
-    "bg-[#1E1E1E] text-white shadow-md"
+  defp color_variant("bordered", "dark") do
+    [
+      "bg-[#282828] text-white border-[#727272]"
+    ]
   end
+  <% end %>
+  <%= if is_nil(@color) or "natural" in @color do %>
+  defp color_variant("bordered", "natural") do
+    [
+      "text-[#282828] border-[#282828] bg-[#F3F3F3]",
+      "dark:text-[#E8E8E8] dark:border-[#E8E8E8] dark:bg-[#4B4B4B]"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "primary" in @color do %>
+  defp color_variant("bordered", "primary") do
+    [
+      "text-[#016974] border-[#016974] bg-[#E2F8FB]",
+      "dark:text-[#77D5E3] dark:border-[#77D5E3] dark:bg-[#002D33]"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "secondary" in @color do %>
+  defp color_variant("bordered", "secondary") do
+    [
+      "text-[#175BCC] border-[#175BCC] bg-[#EFF4FE]",
+      "dark:text-[#A9C9FF] dark:border-[#A9C9FF] dark:bg-[#002661]"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "success" in @color do %>
+  defp color_variant("bordered", "success") do
+    [
+      "text-[#166C3B] border-[#166C3B] bg-[#EAF6ED]",
+      "dark:text-[#7FD99A] dark:border-[#7FD99A] dark:bg-[#002F14]"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "warning" in @color do %>
+  defp color_variant("bordered", "warning") do
+    [
+      "text-[#976A01] border-[#976A01] bg-[#FFF7E6]",
+      "dark:text-[#FDD067] dark:border-[#FDD067] dark:bg-[#322300]"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "danger" in @color do %>
+  defp color_variant("bordered", "danger") do
+    [
+      "text-[#BB032A] border-[#BB032A] bg-[#FFF0EE]",
+      "dark:text-[#FFB2AB] dark:border-[#FFB2AB] dark:bg-[#520810]"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "info" in @color do %>
+  defp color_variant("bordered", "info") do
+    [
+      "text-[#0B84BA] border-[#0B84BA] bg-[#E7F6FD]",
+      "dark:text-[#6EC9F2] dark:border-[#6EC9F2] dark:bg-[#03212F]"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "misc" in @color do %>
+  defp color_variant("bordered", "misc") do
+    [
+      "text-[#653C94] border-[#653C94] bg-[#F6F0FE]",
+      "dark:text-[#CBA2FA] dark:border-[#CBA2FA] dark:bg-[#221431]"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "dawn" in @color do %>
+  defp color_variant("bordered", "dawn") do
+    [
+      "text-[#7E4B2A] border-[#7E4B2A] bg-[#FBF2ED]",
+      "dark:text-[#E4B190] dark:border-[#E4B190] dark:bg-[#2A190E]"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "silver" in @color do %>
+  defp color_variant("bordered", "silver") do
+    [
+      "text-[#727272] border-[#727272] bg-[#F3F3F3]",
+      "dark:text-[#BBBBBB] dark:border-[#BBBBBB] dark:bg-[#4B4B4B]"
+    ]
+  end
+  <% end %>
+  <% end %>
+  <%= if is_nil(@variant) or "gradient" in @variant do %>
+  <%= if is_nil(@color) or "natural" in @color do %>
+  defp color_variant("gradient", "natural") do
+    [
+      "bg-gradient-to-br from-[#282828] to-[#727272] text-white",
+      "dark:from-[#A6A6A6] dark:to-[#FFFFFF] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "primary" in @color do %>
+  defp color_variant("gradient", "primary") do
+    [
+      "bg-gradient-to-br from-[#016974] to-[#01B8CA] text-white",
+      "dark:from-[#01B8CA] dark:to-[#B0E7EF] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "secondary" in @color do %>
+  defp color_variant("gradient", "secondary") do
+    [
+      "bg-gradient-to-br from-[#175BCC] to-[#6DAAFB] text-white",
+      "dark:from-[#6DAAFB] dark:to-[#CDDEFF] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "success" in @color do %>
+  defp color_variant("gradient", "success") do
+    [
+      "bg-gradient-to-br from-[#166C3B] to-[#06C167] text-white",
+      "dark:from-[#06C167] dark:to-[#B1EAC2] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "warning" in @color do %>
+  defp color_variant("gradient", "warning") do
+    [
+      "bg-gradient-to-br from-[#976A01] to-[#FDC034] text-white",
+      "dark:from-[#FDC034] dark:to-[#FEDF99] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "danger" in @color do %>
+  defp color_variant("gradient", "danger") do
+    [
+      "bg-gradient-to-br from-[#BB032A] to-[#FC7F79] text-white",
+      "dark:from-[#FC7F79] dark:to-[#FFD2CD] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "info" in @color do %>
+  defp color_variant("gradient", "info") do
+    [
+      "bg-gradient-to-br from-[#08638C] to-[#3EB7ED] text-white",
+      "dark:from-[#3EB7ED] dark:to-[#9FDBF6] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "misc" in @color do %>
+  defp color_variant("gradient", "misc") do
+   [
+      "bg-gradient-to-br from-[#653C94] to-[#BA83F9] text-white",
+      "dark:from-[#BA83F9] dark:to-[#DDC1FC] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "dawn" in @color do %>
+  defp color_variant("gradient", "dawn") do
+    [
+      "bg-gradient-to-br from-[#7E4B2A] to-[#DB976B] text-white",
+      "dark:from-[#DB976B] dark:to-[#EDCBB5] dark:text-black"
+    ]
+  end
+  <% end %>
+  <%= if is_nil(@color) or "silver" in @color do %>
+  defp color_variant("gradient", "silver") do
+    [
+      "bg-gradient-to-br from-[#5E5E5E] to-[#A6A6A6] text-white",
+      "dark:from-[#868686] dark:to-[#BBBBBB] dark:text-black"
+    ]
+  end
+  <% end %>
+  <% end %>
+  defp color_variant(params,_) when is_binary(params), do: params
+  <%= if is_nil(@variant) or "default" in @variant do %>
+  <%= if is_nil(@color) or "natural" in @color do %>
+  defp color_variant(_,_), do: color_variant("default", "natural")
   <% end %>
   <% end %>
 end

--- a/priv/templates/components/popover.exs
+++ b/priv/templates/components/popover.exs
@@ -2,7 +2,7 @@
   popover: [
     name: "popover",
     args: [
-      variant: ["default", "shadow"],
+      variant: ["default", "shadow", "bordered", "gradient"],
       color: [
         "white",
         "primary",
@@ -12,7 +12,7 @@
         "warning",
         "danger",
         "info",
-        "light",
+        "silver",
         "misc",
         "dawn"
       ],

--- a/priv/templates/components/popover.exs
+++ b/priv/templates/components/popover.exs
@@ -4,6 +4,7 @@
     args: [
       variant: ["default", "shadow", "bordered", "gradient"],
       color: [
+        "natural",
         "white",
         "primary",
         "secondary",
@@ -22,6 +23,7 @@
       space: ["extra_small", "small", "medium", "large", "extra_large"],
       type: ["popover", "popover_trigger", "popover_content"],
       only: ["popover", "popover_trigger", "popover_content"],
+      helpers: [],
       module: ""
     ],
     optional: [],


### PR DESCRIPTION
**Summary**:

- Add variant `gradient` and `bordered`
- Modify colors add support of dark mode
- Add a new prop `show_arrow` to help user control showing of arrow of popover

**Example usage of `show_arrow`**

> If you do not set this property, it will be set to true and the arrow will appear

```elixir
<.popover>
   <.popover_trigger></.popover_trigger>
   <.popover_content show_arrow={false}></.popover_content>
</.popover>

<.popover>
   <.popover_trigger></.popover_trigger>
   <.popover_content show_arrow={true}></.popover_content>
</.popover>
```

Close #116 