### PR TITLE
Chore: Remove `space-y-0` classes from Menu, Footer, Navbar, Tooltip components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - Revision and fix some missing part of some fields (version 0.0.1) [#84](https://github.com/mishka-group/mishka_chelekom/pull/84)
 - Fix without `--import` option error of components task CLI [b0b7492](https://github.com/mishka-group/mishka_chelekom/commit/b0b7492e636663d2c55d4b56a04c89b2376f422a)
 - Fix issue of breadcrumb RTL mode [#170](https://github.com/mishka-group/mishka_chelekom/pull/170)
+- Remove space-y-0 classes from Menu, Footer, Navbar, Tooltip components [#183](https://github.com/mishka-group/mishka_chelekom/pull/183)
 
 ---
 

--- a/priv/templates/components/footer.eex
+++ b/priv/templates/components/footer.eex
@@ -182,7 +182,7 @@ defmodule <%= @module %> do
   defp space_class("extra_large"), do: "space-y-6"
   <% end %>
   defp space_class(params) when is_binary(params), do: params
-  defp space_class(_), do: "space-y-0"
+  defp space_class(_), do: nil
 
   defp maximum_width("extra_small"), do: "[&>div]:max-w-3xl	[&>div]:mx-auto"
   defp maximum_width("small"), do: "[&>div]:max-w-4xl [&>div]:mx-auto"

--- a/priv/templates/components/menu.eex
+++ b/priv/templates/components/menu.eex
@@ -403,6 +403,9 @@ defmodule <%= @module %> do
   <%= if is_nil(@padding) or "extra_small" in @padding do %>
   defp padding_size(_), do: padding_size("extra_small")
   <% end %>
+  <%= if is_nil(@space) or "none" in @space do %>
+  defp space_class("none"), do: nil
+  <% end %>
   <%= if is_nil(@space) or "extra_small" in @space do %>
   defp space_class("extra_small"), do: "space-y-2"
   <% end %>
@@ -419,5 +422,5 @@ defmodule <%= @module %> do
   defp space_class("extra_large"), do: "space-y-6"
   <% end %>
   defp space_class(params) when is_binary(params), do: params
-  defp space_class(_), do: "space-y-0"
+  defp space_class(_), do: space_class("small")
 end

--- a/priv/templates/components/navbar.eex
+++ b/priv/templates/components/navbar.eex
@@ -259,7 +259,7 @@ defmodule <%= @module %> do
   defp space_class("extra_large"), do: "space-y-6"
   <% end %>
   defp space_class(params) when is_binary(params), do: params
-  defp space_class(_), do: "space-y-0"
+  defp space_class(_), do: nil
 
   defp maximum_width("extra_small"), do: "[&_.nav-wrapper]:max-w-3xl	[&_.nav-wrapper]:mx-auto"
   defp maximum_width("small"), do: "[&_.nav-wrapper]:max-w-4xl [&_.nav-wrapper]:mx-auto"

--- a/priv/templates/components/tooltip.eex
+++ b/priv/templates/components/tooltip.eex
@@ -283,7 +283,7 @@ defmodule <%= @module %> do
   defp space_class("extra_large"), do: "space-y-6"
   <% end %>
   defp space_class(params) when is_binary(params), do: params
-  defp space_class(_), do: "space-y-0"
+  defp space_class(_), do: nil
 
   <%= if is_nil(@variant) or "default" in @variant do %>
   <%= if is_nil(@color) or "white" in @color do %>


### PR DESCRIPTION
Close #182