### PR TITLE
Chore: Modify structure of popover and dropdown components

### DIFF
--- a/priv/templates/components/dropdown.eex
+++ b/priv/templates/components/dropdown.eex
@@ -42,43 +42,43 @@ defmodule <%= @module %> do
 
   ```elixir
   <.dropdown relative="relative" position="right">
-    <.dropdown_trigger>
+    <:trigger>
       <.button color="primary" icon="hero-chevron-down" right_icon>
         Dropdown Right
       </.button>
-    </.dropdown_trigger>
+    </:trigger>
 
-    <.dropdown_content space="small" rounded="large" width="full" padding="extra_small">
+    <:contents space="small" rounded="large" width="full" padding="extra_small">
       <.list size="small">
         <:item padding="extra_small" icon="hero-envelope">Dashboard</:item>
         <:item padding="extra_small" icon="hero-camera">Settings</:item>
         <:item padding="extra_small" icon="hero-camera">Earning</:item>
         <:item padding="extra_small" icon="hero-calendar">Sign out</:item>
       </.list>
-    </.dropdown_content>
+    </:contents>
   </.dropdown>
 
   <.dropdown relative="relative" clickable>
-    <.dropdown_trigger trigger_id="test-1">
+    <:trigger trigger_id="test-1">
       <.button color="primary" icon="hero-chevron-down" right_icon>
         Dropdown Button
       </.button>
-    </.dropdown_trigger>
+    </:trigger>
 
-    <.dropdown_content id="test-1" space="small" rounded="large" width="full" padding="extra_small">
+    <:contents id="test-1" space="small" rounded="large" width="full" padding="extra_small">
       <.list size="small">
         <:item padding="extra_small" icon="hero-envelope">Dashboard</:item>
         <:item padding="extra_small" icon="hero-camera">Settings</:item>
         <:item padding="extra_small" icon="hero-camera">Earning</:item>
         <:item padding="extra_small" icon="hero-calendar">Sign out</:item>
       </.list>
-    </.dropdown_content>
+    </:contents>
   </.dropdown>
   ```
   """
   @doc type: :component
   attr :id, :string,
-    default: nil,
+    required: true,
     doc: "A unique identifier is used to manage state and interaction"
 
   attr :class, :string, default: nil, doc: "Custom CSS class for additional styling"
@@ -90,10 +90,14 @@ defmodule <%= @module %> do
     default: false,
     doc: "Determines if the element can be activated on click"
 
- attr :variant, :string, values: @variants, default: "default", doc: "Determines the style"
+  attr :nomobile, :boolean,
+    default: false,
+    doc: "Controls whether the dropdown is disabled on mobile devices"
+
+  attr :variant, :string, values: @variants, default: "default", doc: "Determines the style"
   attr :color, :string, values: @colors, default: "natural", doc: "Determines color theme"
   attr :rounded, :string, default: nil, doc: "Determines the border radius"
-  attr :content_width, :string, default: "extra_large", doc: "Determines the element width"
+  attr :contents_width, :string, default: "extra_large", doc: "Determines the element width"
 
   attr :size, :string,
     default: nil,
@@ -119,7 +123,7 @@ defmodule <%= @module %> do
     attr :class, :string, doc: "Custom CSS class for additional styling"
   end
 
-  slot :contents, required: false do
+  slot :contentss, required: false do
     attr :class, :string, doc: "Custom CSS class for additional styling"
   end
 

--- a/priv/templates/components/dropdown.eex
+++ b/priv/templates/components/dropdown.eex
@@ -179,6 +179,130 @@ defmodule <%= @module %> do
       >
         {render_slot(content)}
       </div>
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+  <% end %>
+  <%= if is_nil(@type) or "dropdown_trigger" in @type do %>
+  @doc """
+  Defines a trigger for the dropdown component. When the element is clicked,
+  it toggles the visibility of the associated dropdown content.
+
+  ## Examples
+
+  ```elixir
+  <.dropdown_trigger>
+    <.button color="primary" icon="hero-chevron-down" right_icon>Dropdown Right</.button>
+  </.dropdown_trigger>
+  ```
+  """
+  @doc type: :component
+  attr :id, :string,
+    default: nil,
+    doc: "A unique identifier is used to manage state and interaction"
+
+  attr :trigger_id, :string, default: nil, doc: "Identifies what is the triggered element id"
+  attr :class, :string, default: nil, doc: "Custom CSS class for additional styling"
+  slot :inner_block, required: false, doc: "Inner block that renders HEEx content"
+
+  attr :rest, :global,
+    doc:
+      "Global attributes can define defaults which are merged with attributes provided by the caller"
+
+  def dropdown_trigger(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      phx-click={
+        @trigger_id &&
+          JS.toggle_class("show-dropdown",
+            to: "##{@trigger_id}-dropdown-content",
+            transition: "duration-100"
+          )
+      }
+      class={["cursor-pointer dropdown-trigger", @class]}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+  <% end %>
+
+  <%= if is_nil(@type) or "dropdown_content" in @type do %>
+  @doc """
+  Defines the content area of a dropdown component. The content appears when the dropdown trigger
+  is activated and can be customized with various styles such as size, color, padding, and border.
+
+  ## Examples
+
+  ```elixir
+  <.dropdown_content space="small" rounded="large" width="full" padding="extra_small">
+    <.list size="small">
+      <:item padding="extra_small" icon="hero-envelope">Dashboard</:item>
+      <:item padding="extra_small" icon="hero-camera">Settings</:item>
+      <:item padding="extra_small" icon="hero-camera">Earning</:item>
+      <:item padding="extra_small" icon="hero-calendar">Sign out</:item>
+    </.list>
+  </.dropdown_content>
+  ```
+  """
+  @doc type: :component
+  attr :id, :string,
+    default: nil,
+    doc: "A unique identifier is used to manage state and interaction"
+
+  attr :variant, :string, values: @variants, default: "default", doc: "Determines the style"
+  attr :color, :string, values: @colors, default: "natural", doc: "Determines color theme"
+  attr :rounded, :string, default: nil, doc: "Determines the border radius"
+
+  attr :size, :string,
+    default: nil,
+    doc:
+      "Determines the overall size of the elements, including padding, font size, and other items"
+
+  attr :space, :string, default: nil, doc: "Space between items"
+  attr :width, :string, default: "extra_large", doc: "Determines the element width"
+
+  attr :font_weight, :string,
+    default: "font-normal",
+    doc: "Determines custom class for the font weight"
+
+  attr :padding, :string, default: "none", doc: "Determines padding for items"
+  attr :border, :string, default: "extra_small", doc: "Determines border style"
+  attr :class, :string, default: nil, doc: "Custom CSS class for additional styling"
+
+  attr :rest, :global,
+    doc:
+      "Global attributes can define defaults which are merged with attributes provided by the caller"
+
+  slot :inner_block, required: false, doc: "Inner block that renders HEEx content"
+
+  def dropdown_content(assigns) do
+    ~H"""
+    <div
+      id={@id && "#{@id}-dropdown-content"}
+      phx-click-away={
+        @id &&
+          JS.remove_class("show-dropdown", to: "##{@id}-dropdown-content", transition: "duration-300")
+      }
+      class={[
+        "dropdown-content absolute z-20 transition-all ease-in-out delay-100 duratio-500 w-full",
+        "invisible opacity-0",
+        space_class(@space),
+        color_variant(@variant, @color),
+        rounded_size(@rounded),
+        size_class(@size),
+        width_class(@width),
+        border_class(@border, @variant),
+        padding_size(@padding),
+        @font_weight,
+        @class
+      ]}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
     </div>
     """
   end

--- a/priv/templates/components/dropdown.eex
+++ b/priv/templates/components/dropdown.eex
@@ -90,15 +90,38 @@ defmodule <%= @module %> do
     default: false,
     doc: "Determines if the element can be activated on click"
 
-  attr :nomobile, :boolean,
-    default: false,
-    doc: "Controls whether the dropdown is disabled on mobile devices"
+ attr :variant, :string, values: @variants, default: "default", doc: "Determines the style"
+  attr :color, :string, values: @colors, default: "natural", doc: "Determines color theme"
+  attr :rounded, :string, default: nil, doc: "Determines the border radius"
+  attr :content_width, :string, default: "extra_large", doc: "Determines the element width"
+
+  attr :size, :string,
+    default: nil,
+    doc:
+      "Determines the overall size of the elements, including padding, font size, and other items"
+
+  attr :space, :string, default: nil, doc: "Space between items"
+
+  attr :font_weight, :string,
+    default: "font-normal",
+    doc: "Determines custom class for the font weight"
+
+  attr :padding, :string, default: "none", doc: "Determines padding for items"
+  attr :border, :string, default: "extra_small", doc: "Determines border style"
 
   attr :rest, :global,
     doc:
       "Global attributes can define defaults which are merged with attributes provided by the caller"
 
   slot :inner_block, required: false, doc: "Inner block that renders HEEx content"
+
+  slot :trigger, required: false do
+    attr :class, :string, doc: "Custom CSS class for additional styling"
+  end
+
+  slot :contents, required: false do
+    attr :class, :string, doc: "Custom CSS class for additional styling"
+  end
 
   def dropdown(assigns) do
     ~H"""
@@ -117,130 +140,45 @@ defmodule <%= @module %> do
       ]}
       {@rest}
     >
-      {render_slot(@inner_block)}
-    </div>
-    """
-  end
-  <% end %>
-  <%= if is_nil(@type) or "dropdown_trigger" in @type do %>
-  @doc """
-  Defines a trigger for the dropdown component. When the element is clicked,
-  it toggles the visibility of the associated dropdown content.
+      <div
+        :for={trigger <- @trigger}
+        phx-click={
+          @clickable &&
+            JS.toggle_class("show-dropdown",
+              to: "##{@id}-dropdown-content",
+              transition: "duration-100"
+            )
+        }
+        class={["dropdown-trigger [&>*]:cursor-pointer", trigger[:class]]}
+        {@rest}
+      >
+        {render_slot(trigger)}
+      </div>
 
-  ## Examples
-
-  ```elixir
-  <.dropdown_trigger>
-    <.button color="primary" icon="hero-chevron-down" right_icon>Dropdown Right</.button>
-  </.dropdown_trigger>
-  ```
-  """
-  @doc type: :component
-  attr :id, :string,
-    default: nil,
-    doc: "A unique identifier is used to manage state and interaction"
-
-  attr :trigger_id, :string, default: nil, doc: "Identifies what is the triggered element id"
-  attr :class, :string, default: nil, doc: "Custom CSS class for additional styling"
-  slot :inner_block, required: false, doc: "Inner block that renders HEEx content"
-
-  attr :rest, :global,
-    doc:
-      "Global attributes can define defaults which are merged with attributes provided by the caller"
-
-  def dropdown_trigger(assigns) do
-    ~H"""
-    <div
-      id={@id}
-      phx-click={
-        @trigger_id &&
-          JS.toggle_class("show-dropdown",
-            to: "##{@trigger_id}-dropdown-content",
-            transition: "duration-100"
-          )
-      }
-      class={["cursor-pointer dropdown-trigger", @class]}
-      {@rest}
-    >
-      {render_slot(@inner_block)}
-    </div>
-    """
-  end
-  <% end %>
-
-  <%= if is_nil(@type) or "dropdown_content" in @type do %>
-  @doc """
-  Defines the content area of a dropdown component. The content appears when the dropdown trigger
-  is activated and can be customized with various styles such as size, color, padding, and border.
-
-  ## Examples
-
-  ```elixir
-  <.dropdown_content space="small" rounded="large" width="full" padding="extra_small">
-    <.list size="small">
-      <:item padding="extra_small" icon="hero-envelope">Dashboard</:item>
-      <:item padding="extra_small" icon="hero-camera">Settings</:item>
-      <:item padding="extra_small" icon="hero-camera">Earning</:item>
-      <:item padding="extra_small" icon="hero-calendar">Sign out</:item>
-    </.list>
-  </.dropdown_content>
-  ```
-  """
-  @doc type: :component
-  attr :id, :string,
-    default: nil,
-    doc: "A unique identifier is used to manage state and interaction"
-
-  attr :variant, :string, values: @variants, default: "default", doc: "Determines the style"
-  attr :color, :string, values: @colors, default: "natural", doc: "Determines color theme"
-  attr :rounded, :string, default: nil, doc: "Determines the border radius"
-
-  attr :size, :string,
-    default: nil,
-    doc:
-      "Determines the overall size of the elements, including padding, font size, and other items"
-
-  attr :space, :string, default: nil, doc: "Space between items"
-  attr :width, :string, default: "extra_large", doc: "Determines the element width"
-
-  attr :font_weight, :string,
-    default: "font-normal",
-    doc: "Determines custom class for the font weight"
-
-  attr :padding, :string, default: "none", doc: "Determines padding for items"
-  attr :border, :string, default: "extra_small", doc: "Determines border style"
-  attr :class, :string, default: nil, doc: "Custom CSS class for additional styling"
-
-  attr :rest, :global,
-    doc:
-      "Global attributes can define defaults which are merged with attributes provided by the caller"
-
-  slot :inner_block, required: false, doc: "Inner block that renders HEEx content"
-
-  def dropdown_content(assigns) do
-    ~H"""
-    <div
-      id={@id && "#{@id}-dropdown-content"}
-      phx-click-away={
-        @id &&
-          JS.remove_class("show-dropdown", to: "##{@id}-dropdown-content", transition: "duration-300")
-      }
-      class={[
-        "dropdown-content absolute z-20 transition-all ease-in-out delay-100 duratio-500 w-full",
-        "invisible opacity-0",
-        space_class(@space),
-        color_variant(@variant, @color),
-        rounded_size(@rounded),
-        size_class(@size),
-        width_class(@width),
-        border_class(@border, @variant),
-        padding_size(@padding),
-        @font_weight,
-        @class
-      ]}
-      {@rest}
-    >
-      {render_slot(@inner_block)}
+      <div
+        :for={content <- @contents}
+        id={"#{@id}-dropdown-content"}
+        phx-click-away={
+          @id &&
+            JS.remove_class("show-dropdown", to: "##{@id}-dropdown-content", transition: "duration-300")
+        }
+        class={[
+          "dropdown-content absolute z-20 transition-all ease-in-out delay-100 duratio-500 w-full",
+          "invisible opacity-0",
+          space_class(@space),
+          color_variant(@variant, @color),
+          rounded_size(@rounded),
+          size_class(@size),
+          width_class(@content_width),
+          border_class(@border, @variant),
+          padding_size(@padding),
+          @font_weight,
+          content[:class]
+        ]}
+        {@rest}
+      >
+        {render_slot(content)}
+      </div>
     </div>
     """
   end
@@ -405,7 +343,7 @@ defmodule <%= @module %> do
   defp padding_size("extra_large"), do: "p-6"
   <% end %>
   <%= if is_nil(@padding) or "none" in @padding do %>
-  defp padding_size("none"), do: "p-0"
+  defp padding_size("none"), do: nil
   <% end %>
   defp padding_size(params) when is_binary(params), do: params
   <%= if is_nil(@padding) or "extra_small" in @padding do %>

--- a/priv/templates/components/dropdown.eex
+++ b/priv/templates/components/dropdown.eex
@@ -48,14 +48,14 @@ defmodule <%= @module %> do
       </.button>
     </:trigger>
 
-    <:contents space="small" rounded="large" width="full" padding="extra_small">
+    <:content space="small" rounded="large" width="full" padding="extra_small">
       <.list size="small">
         <:item padding="extra_small" icon="hero-envelope">Dashboard</:item>
         <:item padding="extra_small" icon="hero-camera">Settings</:item>
         <:item padding="extra_small" icon="hero-camera">Earning</:item>
         <:item padding="extra_small" icon="hero-calendar">Sign out</:item>
       </.list>
-    </:contents>
+    </:content>
   </.dropdown>
 
   <.dropdown relative="relative" clickable>
@@ -65,14 +65,14 @@ defmodule <%= @module %> do
       </.button>
     </:trigger>
 
-    <:contents id="test-1" space="small" rounded="large" width="full" padding="extra_small">
+    <:content id="test-1" space="small" rounded="large" width="full" padding="extra_small">
       <.list size="small">
         <:item padding="extra_small" icon="hero-envelope">Dashboard</:item>
         <:item padding="extra_small" icon="hero-camera">Settings</:item>
         <:item padding="extra_small" icon="hero-camera">Earning</:item>
         <:item padding="extra_small" icon="hero-calendar">Sign out</:item>
       </.list>
-    </:contents>
+    </:content>
   </.dropdown>
   ```
   """
@@ -123,7 +123,7 @@ defmodule <%= @module %> do
     attr :class, :string, doc: "Custom CSS class for additional styling"
   end
 
-  slot :contents, required: false do
+  slot :content, required: false do
     attr :class, :string, doc: "Custom CSS class for additional styling"
   end
 
@@ -160,7 +160,7 @@ defmodule <%= @module %> do
       </div>
 
       <div
-        :for={content <- @contents}
+        :for={content <- @content}
         id={"#{@id}-dropdown-content"}
         phx-click-away={
           @id &&

--- a/priv/templates/components/dropdown.eex
+++ b/priv/templates/components/dropdown.eex
@@ -97,7 +97,7 @@ defmodule <%= @module %> do
   attr :variant, :string, values: @variants, default: "default", doc: "Determines the style"
   attr :color, :string, values: @colors, default: "natural", doc: "Determines color theme"
   attr :rounded, :string, default: nil, doc: "Determines the border radius"
-  attr :contents_width, :string, default: "extra_large", doc: "Determines the element width"
+  attr :content_width, :string, default: "extra_large", doc: "Determines the element width"
 
   attr :size, :string,
     default: nil,
@@ -123,7 +123,7 @@ defmodule <%= @module %> do
     attr :class, :string, doc: "Custom CSS class for additional styling"
   end
 
-  slot :contentss, required: false do
+  slot :contents, required: false do
     attr :class, :string, doc: "Custom CSS class for additional styling"
   end
 

--- a/priv/templates/components/dropdown.exs
+++ b/priv/templates/components/dropdown.exs
@@ -21,8 +21,8 @@
       space: ["extra_small", "small", "medium", "large", "extra_large"],
       rounded: ["extra_small", "small", "medium", "large", "extra_large", "none"],
       padding: ["extra_small", "small", "medium", "large", "extra_large", "none"],
-      type: ["dropdown"],
-      only: ["dropdown"],
+      type: ["dropdown", "dropdown_trigger", "dropdown_content"],
+      only: ["dropdown", "dropdown_trigger", "dropdown_content"],
       helpers: [],
       module: ""
     ],

--- a/priv/templates/components/dropdown.exs
+++ b/priv/templates/components/dropdown.exs
@@ -21,8 +21,8 @@
       space: ["extra_small", "small", "medium", "large", "extra_large"],
       rounded: ["extra_small", "small", "medium", "large", "extra_large", "none"],
       padding: ["extra_small", "small", "medium", "large", "extra_large", "none"],
-      type: ["dropdown", "dropdown_trigger", "dropdown_content"],
-      only: ["dropdown", "dropdown_trigger", "dropdown_content"],
+      type: ["dropdown"],
+      only: ["dropdown"],
       helpers: [],
       module: ""
     ],

--- a/priv/templates/components/navbar.eex
+++ b/priv/templates/components/navbar.eex
@@ -47,24 +47,24 @@ defmodule <%= @module %> do
 
     <:list>
       <.dropdown relative="md:relative" width="w-full" clickable>
-        <.dropdown_trigger width="full" trigger_id="test-31">
+        <:trigger width="full" trigger_id="test-31">
           <button class="text-start w-full block">Dropdown</button>
-        </.dropdown_trigger>
+        </:trigger>
 
-        <.dropdown_content space="small" id="test-31" rounded="large" width="large" padding="extra_small">
+        <:content space="small" id="test-31" rounded="large" width="large" padding="extra_small">
           <ul class="space-y-5">
             <li>
               <.dropdown width="w-full" position="right" clickable>
-                <.dropdown_trigger trigger_id="test-19">
+                <:trigger trigger_id="test-19">
                   <button class={[
                     "py-1 px-2 text-start w-full flex items-center justify-between hover:bg-gray-200"
                   ]}
                   >
                     Nested Dropdown <.icon name="hero-chevron-right" />
                   </button>
-                </.dropdown_trigger>
+                </:trigger>
 
-                <.dropdown_content id="test-19" rounded="large" width="large" padding="extra_small">
+                <:content id="test-19" rounded="large" width="large" padding="extra_small">
                   <ul class="space-y-5">
                     <li>
                       <.link class="py-1 px-2 block hover:bg-gray-200" navigate="/examples/list">
@@ -84,7 +84,7 @@ defmodule <%= @module %> do
                       </.link>
                     </li>
                   </ul>
-                </.dropdown_content>
+                </:content>
               </.dropdown>
             </li>
 
@@ -100,7 +100,7 @@ defmodule <%= @module %> do
               </.link>
             </li>
           </ul>
-        </.dropdown_content>
+        </:content>
       </.dropdown>
     </:list>
 

--- a/priv/templates/components/popover.eex
+++ b/priv/templates/components/popover.eex
@@ -94,7 +94,7 @@ defmodule <%= @module %> do
   """
   @doc type: :component
   attr :id, :string,
-    default: nil,
+    required: true,
     doc: "A unique identifier is used to manage state and interaction"
 
   attr :class, :string, default: nil, doc: "Custom CSS class for additional styling"

--- a/priv/templates/components/popover.eex
+++ b/priv/templates/components/popover.eex
@@ -52,8 +52,8 @@ defmodule <%= @module %> do
   <p>
     Due to its central geographic location in Southern Europe,
     <.popover inline clickable>
-      <.popover_trigger trigger_id="popover-1" inline class="text-blue-400">Italy</.popover_trigger>
-      <.popover_content
+      <:trigger trigger_id="popover-1" inline class="text-blue-400">Italy</:trigger>
+      <:content
         id="popover-1"
         rounded="large"
         width="quadruple_large"
@@ -76,19 +76,19 @@ defmodule <%= @module %> do
           class="h-full w-full col-span-2"
           alt="Map of Italy"
         />
-      </.popover_content>
+      </:content>
     </.popover>
     has historically been home to myriad peoples and cultures. In addition to the various ancient peoples dispersed throughout what is now modern-day Italy, the most predominant being the Indo-European Italic peoples who gave the peninsula its name, beginning from the classical era, Phoenicians and Carthaginians founded colonies mostly in insular Italy.
   </p>
 
   <.popover clickable>
-    <.popover_trigger trigger_id="popover-2" class="text-blue-400">Hover or Click here</.popover_trigger>
-    <.popover_content id="popover-2" color="light" rounded="large" padding="medium">
+    <:trigger trigger_id="popover-2" class="text-blue-400">Hover or Click here</:trigger>
+    <:content id="popover-2" color="light" rounded="large" padding="medium">
       <div class="p-4">
         <h4 class="text-lg font-semibold">Popover Title</h4>
         <p class="mt-2">This is a simple popover example with content that can be customized.</p>
       </div>
-    </.popover_content>
+    </:content>
   </.popover>
   ```
   """
@@ -104,160 +104,7 @@ defmodule <%= @module %> do
     default: false,
     doc: "Determines if the element can be activated on click"
 
-  attr :rest, :global,
-    doc:
-      "Global attributes can define defaults which are merged with attributes provided by the caller"
 
-  slot :inner_block, required: false, doc: "Inner block that renders HEEx content"
-
-  def popover(%{inline: true} = assigns) do
-    ~H"""
-    <span
-      id={@id}
-      class={[
-        "inline-block relative w-fit",
-        "[&_.popover-content]:invisible [&_.popover-content]:opacity-0",
-        "[&_.popover-content.show-popover]:visible [&_.popover-content.show-popover]:opacity-100",
-        !@clickable && tirgger_popover(),
-        @class
-      ]}
-      {@rest}
-    >
-      {render_slot(@inner_block)}
-    </span>
-    """
-  end
-
-  def popover(assigns) do
-    ~H"""
-    <div
-      id={@id}
-      class={[
-        "relative w-fit",
-        "[&_.popover-content]:invisible [&_.popover-content]:opacity-0",
-        "[&_.popover-content.show-popover]:visible [&_.popover-content.show-popover]:opacity-100",
-        !@clickable && tirgger_popover(),
-        @class
-      ]}
-      {@rest}
-    >
-      {render_slot(@inner_block)}
-    </div>
-    """
-  end
-  <% end %>
-  <%= if is_nil(@type) or "popover_trigger" in @type do %>
-  @doc """
-  Renders a `popover_trigger` element, which is used to show or hide a popover content element.
-  The trigger can be rendered as either an inline or block element. When the trigger is clicked,
-  it toggles the visibility of the associated popover content.
-
-  ## Examples
-
-  ```elixir
-  <p>
-    Discover more about
-    <.popover_trigger trigger_id="popover-1" inline class="text-blue-400">Italy</.popover_trigger>
-    by clicking on the name.
-    <.popover_content
-      id="popover-1"
-      inline
-      rounded="large"
-      width="quadruple_large"
-      color="light"
-      padding="none"
-      class="grid grid-cols-5"
-    >
-      <span class="block p-2 space-y-5 col-span-3">
-        <span class="font-semibold block">About Italy</span>
-        <span class="block">
-          Italy is located in the middle of the Mediterranean Sea, in Southern Europe, and it is also considered part of Western Europe. It is a unitary parliamentary republic with Rome as its capital and largest city.
-        </span>
-        <a href="/" class="block text-blue-400">Read more <.icon name="hero-link" /></a>
-      </span>
-      <img
-        src="https://flowbite.com/docs/images/popovers/italy.png"
-        class="h-full w-full col-span-2"
-        alt="Map of Italy"
-      />
-    </.popover_content>
-  </p>
-
-  <.popover_trigger trigger_id="popover-2" class="text-blue-400">
-    Hover or Click here to show the popover
-  </.popover_trigger>
-  <.popover_content id="popover-2" color="light" rounded="large" padding="medium">
-    <div class="p-4">
-      <h4 class="text-lg font-semibold">Popover Title</h4>
-      <p class="mt-2">This is a simple popover example with content that can be customized.</p>
-    </div>
-  </.popover_content>
-  ```
-  """
-  @doc type: :component
-  attr :id, :string,
-    default: nil,
-    doc: "A unique identifier is used to manage state and interaction"
-
-  attr :trigger_id, :string, default: nil, doc: "Identifies what is the triggered element id"
-  attr :class, :string, default: nil, doc: "Custom CSS class for additional styling"
-  attr :inline, :boolean, default: false, doc: "Determines whether this element is inline"
-  slot :inner_block, required: false, doc: "Inner block that renders HEEx content"
-
-  attr :rest, :global,
-    doc:
-      "Global attributes can define defaults which are merged with attributes provided by the caller"
-
-  def popover_trigger(%{inline: true} = assigns) do
-    ~H"""
-    <span
-      id={@id}
-      phx-click-away={@trigger_id && JS.remove_class("show-popover", to: "##{@trigger_id}")}
-      phx-click={@trigger_id && JS.toggle_class("show-popover", to: "##{@trigger_id}")}
-      class={["inline-block cursor-pointer popover-trigger", @class]}
-      {@rest}
-    >
-      {render_slot(@inner_block)}
-    </span>
-    """
-  end
-
-  def popover_trigger(assigns) do
-    ~H"""
-    <div
-      id={@id}
-      phx-click-away={@trigger_id && JS.remove_class("show-popover", to: "##{@trigger_id}")}
-      phx-click={@trigger_id && JS.toggle_class("show-popover", to: "##{@trigger_id}")}
-      class={["cursor-pointer popover-trigger", @class]}
-      {@rest}
-    >
-      {render_slot(@inner_block)}
-    </div>
-    """
-  end
-  <% end %>
-  <%= if is_nil(@type) or "popover_content" in @type do %>
-  @doc """
-  Renders a `popover_content` element, which displays additional information when the associated
-  popover trigger is activated.
-
-  The content can be positioned relative to the trigger and customized with various styles,
-  such as color, padding, and size.
-
-  ## Examples
-
-  ```elixir
-  <.popover_content id="popover-3" inline position="top" color="dark" rounded="small" padding="small">
-    <span class="block text-white p-2">This is a tooltip message!</span>
-  </.popover_content>
-  ```
-  """
-  @doc type: :component
-  attr :id, :string,
-    default: nil,
-    doc: "A unique identifier is used to manage state and interaction"
-
-  attr :inline, :boolean, default: false, doc: "Determines whether this element is inline"
   attr :position, :string, default: "top", doc: "Determines the element position"
   attr :variant, :string, values: @variants, default: "shadow", doc: "Determines the style"
   attr :color, :string, values: @colors, default: "natural", doc: "Determines color theme"
@@ -279,66 +126,128 @@ defmodule <%= @module %> do
     doc: "Determines custom class for the font weight"
 
   attr :padding, :string, default: "none", doc: "Determines padding for items"
-  attr :class, :string, default: nil, doc: "Custom CSS class for additional styling"
 
   attr :rest, :global,
-    doc:
-      "Global attributes can define defaults which are merged with attributes provided by the caller"
+  doc:
+    "Global attributes can define defaults which are merged with attributes provided by the caller"
 
   slot :inner_block, required: false, doc: "Inner block that renders HEEx content"
 
-  def popover_content(%{inline: true} = assigns) do
-    ~H"""
-    <span
-      role="tooltip"
-      id={@id}
-      class={[
-        "popover-content absolute z-10 w-full",
-        "transition-all ease-in-out delay-100 duratio-500",
-        space_class(@space),
-        color_variant(@variant, @color),
-        rounded_size(@rounded),
-        size_class(@size),
-        position_class(@position),
-        text_position(@text_position),
-        @variant == "bordered" && border_class(@border),
-        width_class(@width),
-        wrapper_padding(@padding),
-        @font_weight,
-        @class
-      ]}
-      {@rest}
-    >
-      {render_slot(@inner_block)}
-      <span :if={@show_arrow && @variant != "bordered"} class={["block absolute size-[8px] bg-inherit rotate-45 popover-arrow"]}></span>
-    </span>
-    """
+  slot :contents, required: true do
+    attr :class, :string, doc: "Custom CSS class for additional styling"
   end
 
-  def popover_content(assigns) do
+  slot :trigger, required: true do
+    attr :class, :string, doc: "Custom CSS class for additional styling"
+  end
+
+  def popover(assigns) do
     ~H"""
-    <div
-      role="dialog "
+    <span
       id={@id}
+      :if={@inline}
       class={[
-        "popover-content absolute z-10 w-full",
-        "transition-all ease-in-out delay-100 duratio-500",
-        space_class(@space),
-        color_variant(@variant, @color),
-        rounded_size(@rounded),
-        size_class(@size),
-        position_class(@position),
-        text_position(@text_position),
-        @variant == "bordered" && border_class(@border),
-        width_class(@width),
-        wrapper_padding(@padding),
-        @font_weight,
+        "inline-block relative w-fit",
+        "[&_.popover-content]:invisible [&_.popover-content]:opacity-0",
+        "[&_.popover-content.show-popover]:visible [&_.popover-content.show-popover]:opacity-100",
+        !@clickable && tirgger_popover(),
         @class
       ]}
       {@rest}
     >
-      {render_slot(@inner_block)}
-      <span :if={@show_arrow && @variant != "bordered"} class={["block absolute size-[8px] bg-inherit rotate-45 popover-arrow"]}></span>
+
+      <span
+        :for={trigger <- @trigger}
+        phx-click-away={JS.remove_class("show-popover", to: "##{@id}")}
+        phx-click={JS.toggle_class("show-popover", to: "##{@id}")}
+        class={["inline-block cursor-pointer popover-trigger", trigger[:class]]}
+        {@rest}
+      >
+        {render_slot(trigger)}
+      </span>
+
+       <%!-- Contents --%>
+
+       <span
+        :for={content <- @contents}
+        role="dialog"
+        class={[
+          "popover-content absolute z-10 w-full",
+          "transition-all ease-in-out delay-100 duratio-500",
+          space_class(@space),
+          color_variant(@variant, @color),
+          rounded_size(@rounded),
+          size_class(@size),
+          position_class(@position),
+          text_position(@text_position),
+          @variant == "bordered" && border_class(@border),
+          width_class(@width),
+          wrapper_padding(@padding),
+          @font_weight,
+          content[:class]
+        ]}
+        {@rest}
+      >
+        {render_slot(content)}
+        <span
+          :if={@show_arrow && @variant != "bordered"}
+          class={["block absolute size-[8px] bg-inherit rotate-45 popover-arrow"]}
+        >
+        </span>
+      </span>
+    </span>
+
+    <div
+      :if={!@inline}
+      id={@id}
+      class={[
+        "relative w-fit",
+        "[&_.popover-content]:invisible [&_.popover-content]:opacity-0",
+        "[&_.popover-content.show-popover]:visible [&_.popover-content.show-popover]:opacity-100",
+        !@clickable && tirgger_popover(),
+        @class
+      ]}
+      {@rest}
+    >
+      <div
+        :for={trigger <- @trigger}
+        phx-click-away={JS.remove_class("show-popover", to: "##{@id}")}
+        phx-click={JS.toggle_class("show-popover", to: "##{@id}")}
+        class={["cursor-pointer popover-trigger", trigger[:class]]}
+        {@rest}
+      >
+        {render_slot(trigger)}
+      </div>
+
+      <%!-- Contents --%>
+      <div
+        :for={content <- @contents}
+        role="dialog"
+        id={@id}
+        class={[
+          "popover-content absolute z-10 w-full",
+          "transition-all ease-in-out delay-100 duratio-500",
+          space_class(@space),
+          color_variant(@variant, @color),
+          rounded_size(@rounded),
+          size_class(@size),
+          position_class(@position),
+          text_position(@text_position),
+          @variant == "bordered" && border_class(@border),
+          width_class(@width),
+          wrapper_padding(@padding),
+          @font_weight,
+          content[:class]
+        ]}
+        {@rest}
+      >
+        {render_slot(content)}
+        <span
+          :if={@show_arrow && @variant != "bordered"}
+          class={["block absolute size-[8px] bg-inherit rotate-45 popover-arrow"]}
+        >
+        </span>
+      </div>
     </div>
     """
   end

--- a/priv/templates/components/popover.eex
+++ b/priv/templates/components/popover.eex
@@ -219,7 +219,6 @@ defmodule <%= @module %> do
       <div
         :for={content <- @contents}
         role="dialog"
-        id={@id}
         class={[
           "popover-content absolute z-10 w-full",
           "transition-all ease-in-out delay-100 duratio-500",

--- a/priv/templates/components/popover.eex
+++ b/priv/templates/components/popover.eex
@@ -104,7 +104,6 @@ defmodule <%= @module %> do
     default: false,
     doc: "Determines if the element can be activated on click"
 
-
   attr :position, :string, default: "top", doc: "Determines the element position"
   attr :variant, :string, values: @variants, default: "shadow", doc: "Determines the style"
   attr :color, :string, values: @colors, default: "natural", doc: "Determines color theme"

--- a/priv/templates/components/popover.eex
+++ b/priv/templates/components/popover.eex
@@ -140,7 +140,7 @@ defmodule <%= @module %> do
     attr :class, :string, doc: "Custom CSS class for additional styling"
   end
 
-  def popover(assigns) do
+   def popover(assigns) do
     ~H"""
     <span
       id={@id}
@@ -156,8 +156,8 @@ defmodule <%= @module %> do
     >
       <span
         :for={trigger <- @trigger}
-        phx-click-away={JS.remove_class("show-popover", to: "##{@id}")}
-        phx-click={JS.toggle_class("show-popover", to: "##{@id}")}
+        phx-click-away={JS.remove_class("show-popover", to: "##{@id}-popover-content")}
+        phx-click={JS.toggle_class("show-popover", to: "##{@id}-popover-content")}
         class={["inline-block cursor-pointer popover-trigger", trigger[:class]]}
         {@rest}
       >
@@ -166,6 +166,7 @@ defmodule <%= @module %> do
 
        <span
         :for={content <- @contents}
+        id={"#{@id}-popover-content"}
         role="dialog"
         class={[
           "popover-content absolute z-10 w-full",
@@ -208,8 +209,8 @@ defmodule <%= @module %> do
     >
       <div
         :for={trigger <- @trigger}
-        phx-click-away={JS.remove_class("show-popover", to: "##{@id}")}
-        phx-click={JS.toggle_class("show-popover", to: "##{@id}")}
+        phx-click-away={JS.remove_class("show-popover", to: "##{@id}-popover-content")}
+        phx-click={JS.toggle_class("show-popover", to: "##{@id}-popover-content")}
         class={["cursor-pointer popover-trigger", trigger[:class]]}
         {@rest}
       >
@@ -219,6 +220,7 @@ defmodule <%= @module %> do
       <div
         :for={content <- @contents}
         role="dialog"
+        id={"#{@id}-popover-content"}
         class={[
           "popover-content absolute z-10 w-full",
           "transition-all ease-in-out delay-100 duratio-500",

--- a/priv/templates/components/popover.eex
+++ b/priv/templates/components/popover.eex
@@ -132,7 +132,7 @@ defmodule <%= @module %> do
 
   slot :inner_block, required: false, doc: "Inner block that renders HEEx content"
 
-  slot :contents, required: false do
+  slot :content, required: false do
     attr :class, :string, doc: "Custom CSS class for additional styling"
   end
 
@@ -165,7 +165,7 @@ defmodule <%= @module %> do
       </span>
 
        <span
-        :for={content <- @contents}
+        :for={content <- @content}
         id={"#{@id}-popover-content"}
         role="dialog"
         class={[
@@ -218,7 +218,7 @@ defmodule <%= @module %> do
       </div>
 
       <div
-        :for={content <- @contents}
+        :for={content <- @content}
         role="dialog"
         id={"#{@id}-popover-content"}
         class={[

--- a/priv/templates/components/popover.eex
+++ b/priv/templates/components/popover.eex
@@ -133,11 +133,11 @@ defmodule <%= @module %> do
 
   slot :inner_block, required: false, doc: "Inner block that renders HEEx content"
 
-  slot :contents, required: true do
+  slot :contents, required: false do
     attr :class, :string, doc: "Custom CSS class for additional styling"
   end
 
-  slot :trigger, required: true do
+  slot :trigger, required: false do
     attr :class, :string, doc: "Custom CSS class for additional styling"
   end
 
@@ -155,7 +155,6 @@ defmodule <%= @module %> do
       ]}
       {@rest}
     >
-
       <span
         :for={trigger <- @trigger}
         phx-click-away={JS.remove_class("show-popover", to: "##{@id}")}
@@ -165,8 +164,6 @@ defmodule <%= @module %> do
       >
         {render_slot(trigger)}
       </span>
-
-       <%!-- Contents --%>
 
        <span
         :for={content <- @contents}
@@ -195,6 +192,7 @@ defmodule <%= @module %> do
         >
         </span>
       </span>
+      {render_slot(@inner_block)}
     </span>
 
     <div
@@ -219,7 +217,6 @@ defmodule <%= @module %> do
         {render_slot(trigger)}
       </div>
 
-      <%!-- Contents --%>
       <div
         :for={content <- @contents}
         role="dialog"
@@ -248,6 +245,204 @@ defmodule <%= @module %> do
         >
         </span>
       </div>
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+  <% end %>
+  <%= if is_nil(@type) or "popover_trigger" in @type do %>
+  @doc """
+  Renders a `popover_trigger` element, which is used to show or hide a popover content element.
+  The trigger can be rendered as either an inline or block element. When the trigger is clicked,
+  it toggles the visibility of the associated popover content.
+
+  ## Examples
+
+  ```elixir
+  <p>
+    Discover more about
+    <.popover_trigger trigger_id="popover-1" inline class="text-blue-400">Italy</.popover_trigger>
+    by clicking on the name.
+    <.popover_content
+      id="popover-1"
+      inline
+      rounded="large"
+      width="quadruple_large"
+      color="light"
+      padding="none"
+      class="grid grid-cols-5"
+    >
+      <span class="block p-2 space-y-5 col-span-3">
+        <span class="font-semibold block">About Italy</span>
+        <span class="block">
+          Italy is located in the middle of the Mediterranean Sea, in Southern Europe, and it is also considered part of Western Europe. It is a unitary parliamentary republic with Rome as its capital and largest city.
+        </span>
+        <a href="/" class="block text-blue-400">Read more <.icon name="hero-link" /></a>
+      </span>
+      <img
+        src="https://flowbite.com/docs/images/popovers/italy.png"
+        class="h-full w-full col-span-2"
+        alt="Map of Italy"
+      />
+    </.popover_content>
+  </p>
+
+  <.popover_trigger trigger_id="popover-2" class="text-blue-400">
+    Hover or Click here to show the popover
+  </.popover_trigger>
+  <.popover_content id="popover-2" color="light" rounded="large" padding="medium">
+    <div class="p-4">
+      <h4 class="text-lg font-semibold">Popover Title</h4>
+      <p class="mt-2">This is a simple popover example with content that can be customized.</p>
+    </div>
+  </.popover_content>
+  ```
+  """
+  @doc type: :component
+  attr :id, :string,
+    default: nil,
+    doc: "A unique identifier is used to manage state and interaction"
+
+  attr :trigger_id, :string, default: nil, doc: "Identifies what is the triggered element id"
+  attr :class, :string, default: nil, doc: "Custom CSS class for additional styling"
+  attr :inline, :boolean, default: false, doc: "Determines whether this element is inline"
+  slot :inner_block, required: false, doc: "Inner block that renders HEEx content"
+
+  attr :rest, :global,
+    doc:
+      "Global attributes can define defaults which are merged with attributes provided by the caller"
+
+  def popover_trigger(%{inline: true} = assigns) do
+    ~H"""
+    <span
+      id={@id}
+      phx-click-away={@trigger_id && JS.remove_class("show-popover", to: "##{@trigger_id}")}
+      phx-click={@trigger_id && JS.toggle_class("show-popover", to: "##{@trigger_id}")}
+      class={["inline-block cursor-pointer popover-trigger", @class]}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </span>
+    """
+  end
+
+  def popover_trigger(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      phx-click-away={@trigger_id && JS.remove_class("show-popover", to: "##{@trigger_id}")}
+      phx-click={@trigger_id && JS.toggle_class("show-popover", to: "##{@trigger_id}")}
+      class={["cursor-pointer popover-trigger", @class]}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+  <% end %>
+  <%= if is_nil(@type) or "popover_content" in @type do %>
+  @doc """
+  Renders a `popover_content` element, which displays additional information when the associated
+  popover trigger is activated.
+
+  The content can be positioned relative to the trigger and customized with various styles,
+  such as color, padding, and size.
+
+  ## Examples
+
+  ```elixir
+  <.popover_content id="popover-3" inline position="top" color="dark" rounded="small" padding="small">
+    <span class="block text-white p-2">This is a tooltip message!</span>
+  </.popover_content>
+  ```
+  """
+  @doc type: :component
+  attr :id, :string,
+    default: nil,
+    doc: "A unique identifier is used to manage state and interaction"
+
+  attr :inline, :boolean, default: false, doc: "Determines whether this element is inline"
+  attr :position, :string, default: "top", doc: "Determines the element position"
+  attr :variant, :string, values: @variants, default: "shadow", doc: "Determines the style"
+  attr :color, :string, values: @colors, default: "natural", doc: "Determines color theme"
+  attr :rounded, :string, default: nil, doc: "Determines the border radius"
+  attr :show_arrow, :boolean, default: true, doc: "Show or hide arrow of popover"
+  attr :border, :string, default: "extra_small", doc: "Determines border style"
+
+  attr :size, :string,
+    default: nil,
+    doc:
+      "Determines the overall size of the elements, including padding, font size, and other items"
+
+  attr :space, :string, default: nil, doc: "Space between items"
+  attr :width, :string, default: "extra_large", doc: "Determines the element width"
+  attr :text_position, :string, default: "start", doc: "Determines the element' text position"
+
+  attr :font_weight, :string,
+    default: "font-normal",
+    doc: "Determines custom class for the font weight"
+
+  attr :padding, :string, default: "none", doc: "Determines padding for items"
+  attr :class, :string, default: nil, doc: "Custom CSS class for additional styling"
+
+  attr :rest, :global,
+    doc:
+      "Global attributes can define defaults which are merged with attributes provided by the caller"
+
+  slot :inner_block, required: false, doc: "Inner block that renders HEEx content"
+
+  def popover_content(%{inline: true} = assigns) do
+    ~H"""
+    <span
+      role="tooltip"
+      id={@id}
+      class={[
+        "popover-content absolute z-10 w-full",
+        "transition-all ease-in-out delay-100 duratio-500",
+        space_class(@space),
+        color_variant(@variant, @color),
+        rounded_size(@rounded),
+        size_class(@size),
+        position_class(@position),
+        text_position(@text_position),
+        @variant == "bordered" && border_class(@border),
+        width_class(@width),
+        wrapper_padding(@padding),
+        @font_weight,
+        @class
+      ]}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+      <span :if={@show_arrow && @variant != "bordered"} class={["block absolute size-[8px] bg-inherit rotate-45 popover-arrow"]}></span>
+    </span>
+    """
+  end
+
+  def popover_content(assigns) do
+    ~H"""
+    <div
+      role="dialog "
+      id={@id}
+      class={[
+        "popover-content absolute z-10 w-full",
+        "transition-all ease-in-out delay-100 duratio-500",
+        space_class(@space),
+        color_variant(@variant, @color),
+        rounded_size(@rounded),
+        size_class(@size),
+        position_class(@position),
+        text_position(@text_position),
+        @variant == "bordered" && border_class(@border),
+        width_class(@width),
+        wrapper_padding(@padding),
+        @font_weight,
+        @class
+      ]}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+      <span :if={@show_arrow && @variant != "bordered"} class={["block absolute size-[8px] bg-inherit rotate-45 popover-arrow"]}></span>
     </div>
     """
   end

--- a/priv/templates/components/popover.exs
+++ b/priv/templates/components/popover.exs
@@ -21,8 +21,8 @@
       padding: ["extra_small", "small", "medium", "large", "extra_large", "none"],
       rounded: ["extra_small", "small", "medium", "large", "extra_large", "none"],
       space: ["extra_small", "small", "medium", "large", "extra_large"],
-      type: ["popover"],
-      only: ["popover"],
+      type: ["popover", "popover_trigger", "popover_content"],
+      only: ["popover", "popover_trigger", "popover_content"],
       helpers: [],
       module: ""
     ],

--- a/priv/templates/components/popover.exs
+++ b/priv/templates/components/popover.exs
@@ -21,8 +21,8 @@
       padding: ["extra_small", "small", "medium", "large", "extra_large", "none"],
       rounded: ["extra_small", "small", "medium", "large", "extra_large", "none"],
       space: ["extra_small", "small", "medium", "large", "extra_large"],
-      type: ["popover", "popover_trigger", "popover_content"],
-      only: ["popover", "popover_trigger", "popover_content"],
+      type: ["popover"],
+      only: ["popover"],
       helpers: [],
       module: ""
     ],


### PR DESCRIPTION
Replace the `trigger` and `content` functions with `trigger` and `content` slots in popover and dropdown components

Close #25 