### PR TITLE
Chore: modify styles of form fields, add `badge_position` prop to badge

### DIFF
--- a/priv/templates/components/badge.eex
+++ b/priv/templates/components/badge.eex
@@ -98,6 +98,7 @@ defmodule <%= @module %> do
 
   attr :icon, :string, default: nil, doc: "Icon displayed alongside of an item"
   attr :class, :string, default: nil, doc: "Custom CSS class for additional styling"
+  attr :badge_position, :string, default: nil, doc: "Custom CSS class for additional styling"
 
   attr :indicator_class, :string,
     default: nil,
@@ -128,6 +129,8 @@ defmodule <%= @module %> do
             color_variant(@variant, @color),
             border_size(@border, @variant),
             rounded_size(@rounded),
+            badge_position(@badge_position),
+            @badge_position && "absolute",
             @font_weight,
             @class
           ]
@@ -285,6 +288,18 @@ defmodule <%= @module %> do
     ~H"""
     """
   end
+
+  defp badge_position("top-left"), do: "-translate-y-1/2 -translate-x-1/2 right-auto top-0 left-0"
+
+  defp badge_position("top-right"), do: "-translate-y-1/2 translate-x-1/2 left-auto top-0 right-0"
+
+  defp badge_position("bottom-left"), do: "translate-y-1/2 -translate-x-1/2 right-auto bottom-0 left-0"
+
+  defp badge_position("bottom-right"), do: "translate-y-1/2 translate-x-1/2 left-auto bottom-0 right-0"
+
+  defp badge_position(params) when is_binary(params), do: params
+  defp badge_position(_), do: nil
+
   <%= if is_nil(@variant) or "default" in @variant do %>
   <%= if is_nil(@color) or "white" in @color do %>
   defp color_variant("default", "white") do

--- a/priv/templates/components/date_time_field.eex
+++ b/priv/templates/components/date_time_field.eex
@@ -195,7 +195,7 @@ defmodule <%= @module %> do
             value={@value}
             class={[
               "disabled:opacity-80 block w-full z-[2] focus:ring-0 placeholder:text-transparent pb-1 pt-2.5 px-2",
-              "focus:text-[16px] sm:focus:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer"
+              "text-[16px] sm:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer"
             ]}
             placeholder="select a date "
             {@rest}

--- a/priv/templates/components/email_field.eex
+++ b/priv/templates/components/email_field.eex
@@ -169,7 +169,7 @@ defmodule <%= @module %>  do
             value={@value}
             class={[
               "disabled:opacity-80 block w-full z-[2] focus:ring-0 placeholder:text-transparent pb-1 pt-2.5 px-2",
-              "focus:text-[16px] sm:focus:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer"
+              "text-[16px] sm:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer"
             ]}
             placeholder=" "
             {@rest}

--- a/priv/templates/components/native_select.eex
+++ b/priv/templates/components/native_select.eex
@@ -154,7 +154,7 @@ defmodule <%= @module %> do
         id={@id}
         multiple={@multiple}
         class={[
-          "select-field appearance-none block w-full",
+          "select-field appearance-none block w-full text-[16px] sm:font-inherit",
           @multiple && "select-multiple-option",
           @errors != [] && "select-field-error",
           @min_height,

--- a/priv/templates/components/number_field.eex
+++ b/priv/templates/components/number_field.eex
@@ -161,7 +161,7 @@ defmodule <%= @module %> do
             value={@value}
             class={[
               "disabled:opacity-80 block w-full z-[2] focus:ring-0 placeholder:text-transparent pb-1 pt-2.5 px-2",
-              "focus:text-[16px] sm:focus:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer",
+              "text-[16px] sm:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer",
               @controls == "fixed" &&
                 "[&::-webkit-outer-spin-button]:opacity-100 [&::-webkit-inner-spin-button]:opacity-100",
               @controls == "hide" &&

--- a/priv/templates/components/password_field.eex
+++ b/priv/templates/components/password_field.eex
@@ -167,7 +167,7 @@ defmodule <%= @module %> do
             value={@value}
             class={[
               "disabled:opacity-80 block w-full z-[2] focus:ring-0 placeholder:text-transparent pb-1 pt-2.5 px-2",
-              "focus:text-[16px] sm:focus:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer"
+              "text-[16px] sm:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer"
             ]}
             {@rest}
           />

--- a/priv/templates/components/range_field.eex
+++ b/priv/templates/components/range_field.eex
@@ -284,7 +284,7 @@ defmodule <%= @module %> do
 
   <%= if is_nil(@color) or "white" in @color do %>
   defp color_class("default", "white") do
-      ["accent-white dark:accent-white"]
+      ["accent-white"]
   end
   <% end %>
   <%= if is_nil(@color) or "natural" in @color do %>
@@ -309,7 +309,7 @@ defmodule <%= @module %> do
   <% end %>
   <%= if is_nil(@color) or "warning" in @color do %>
   defp color_class("default", "warning") do
-    ["accent-[#CA8D01] dark:accent-[#FDC034]"]
+    ["accent-[#976A01] dark:accent-[#FDC034]"]
   end
   <% end %>
   <%= if is_nil(@color) or "danger" in @color do %>
@@ -339,7 +339,7 @@ defmodule <%= @module %> do
   <% end %>
   <%= if is_nil(@color) or "dark" in @color do %>
   defp color_class("default", "dark") do
-    ["accent-[#282828] dark:accent-[#282828]"]
+    ["accent-[#282828]"]
   end
   <% end %>
 

--- a/priv/templates/components/search_field.eex
+++ b/priv/templates/components/search_field.eex
@@ -166,7 +166,7 @@ defmodule <%= @module %> do
             value={@value}
             class={[
               "disabled:opacity-80 block w-full z-[2] focus:ring-0 placeholder:text-transparent pb-1 pt-2.5 px-2",
-              "focus:text-[16px] sm:focus:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer"
+              "text-[16px] sm:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer"
             ]}
             placeholder=" "
             {@rest}

--- a/priv/templates/components/tel_field.eex
+++ b/priv/templates/components/tel_field.eex
@@ -170,7 +170,7 @@ defmodule <%= @module %> do
             value={@value}
             class={[
               "disabled:opacity-80 block w-full z-[2] focus:ring-0 placeholder:text-transparent pb-1 pt-2.5 px-2",
-              "focus:text-[16px] sm:focus:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer"
+              "text-[16px] sm:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer"
             ]}
             placeholder=" "
             {@rest}

--- a/priv/templates/components/text_field.eex
+++ b/priv/templates/components/text_field.eex
@@ -173,7 +173,7 @@ defmodule <%= @module %> do
             value={@value}
             class={[
               "disabled:opacity-80 block w-full z-[2] focus:ring-0 placeholder:text-transparent pb-1 pt-2.5 px-2",
-              "focus:text-[16px] sm:focus:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer"
+              "text-[16px] sm:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer"
             ]}
             placeholder=" "
             {@rest}

--- a/priv/templates/components/textarea_field.eex
+++ b/priv/templates/components/textarea_field.eex
@@ -159,7 +159,7 @@ defmodule <%= @module %> do
           value={@value}
           class={[
             "disabled:opacity-80 block w-full z-[2] focus:ring-0 placeholder:text-transparent pb-1 pt-3 px-2",
-            "focus:text-[16px] sm:focus:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer",
+            "text-[16px] sm:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer",
             @disable_resize && "resize-none"
           ]}
           placeholder=" "

--- a/priv/templates/components/url_field.eex
+++ b/priv/templates/components/url_field.eex
@@ -157,7 +157,7 @@ defmodule <%= @module %> do
             value={@value}
             class={[
               "disabled:opacity-80 block w-full z-[2] focus:ring-0 placeholder:text-transparent pb-1 pt-2.5 px-2",
-              "focus:text-[16px] sm:focus:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer"
+              "text-[16px] sm:font-inherit appearance-none bg-transparent border-0 focus:outline-none peer"
             ]}
             placeholder=" "
             {@rest}


### PR DESCRIPTION
- **Changed font size in form fields**:
  - Adjusted font size to address the Safari iOS zooming issue during form input.

- **Added `badge_position` prop to badge**:
  - Supports positioning options like `top-left`, `top-right`, `bottom-left`, and `bottom-right`.
  Close #56 

- **Fixed issue with warning color on range field in light mode**:
  - Adjusted accent color for better visibility in light mode.
  - Based on #79