### PR TITLE
Use more generous dependency on igniter

### DIFF
--- a/lib/mix/tasks/mishka.ui.gen.component.ex
+++ b/lib/mix/tasks/mishka.ui.gen.component.ex
@@ -132,8 +132,7 @@ defmodule Mix.Tasks.Mishka.Ui.Gen.Component do
           Path.join(IAPP.priv_dir(igniter, ["mishka_chelekom", "templates"]), "#{component}.eex")
 
         true ->
-          Application.app_dir(:mishka_chelekom, ["priv", "components"])
-          |> Path.join("#{component}.eex")
+          "deps/mishka_chelekom/priv/components/#{component}.eex"
       end
 
     template_config_path = Path.rootname(template_path) <> ".exs"
@@ -467,8 +466,7 @@ defmodule Mix.Tasks.Mishka.Ui.Gen.Component do
       igniter =
         Enum.reduce(files, igniter, fn item, acc ->
           core_path =
-            Application.app_dir(:mishka_chelekom, ["priv", "assets", "js"])
-            |> Path.join("#{item.file}")
+            "deps/mishka_chelekom/priv/assets/js/#{item.file}"
 
           mishka_user_priv_path =
             Path.join(
@@ -491,9 +489,7 @@ defmodule Mix.Tasks.Mishka.Ui.Gen.Component do
                   content
 
                 _ ->
-                  Application.app_dir(:mishka_chelekom, ["priv", "assets", "js"])
-                  |> Path.join("mishka_components.js")
-                  |> File.read!()
+                  File.read!("deps/mishka_chelekom/priv/assets/js/mishka_components.js")
               end
 
             acc

--- a/lib/mix/tasks/mishka.ui.gen.components.ex
+++ b/lib/mix/tasks/mishka.ui.gen.components.ex
@@ -240,7 +240,7 @@ defmodule Mix.Tasks.Mishka.Ui.Gen.Components do
 
   defp get_all_components_names(igniter) do
     [
-      Application.app_dir(:mishka_chelekom, ["priv", "components"]),
+      "deps/mishka_chelekom/priv/components",
       IAPP.priv_dir(igniter, ["mishka_chelekom", "components"]),
       IAPP.priv_dir(igniter, ["mishka_chelekom", "templates"]),
       IAPP.priv_dir(igniter, ["mishka_chelekom", "presets"])

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule MishkaChelekom.MixProject do
 
   defp deps do
     [
-      {:igniter, "~> 0.5 and >= 0.5.31"},
+      {:igniter, "~> 0.5 and >= 0.5.35"},
       {:guarded_struct, "~> 0.0.4"},
       {:igniter_js, "~> 0.4.6"},
       {:owl, "~> 0.12.2"},

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule MishkaChelekom.MixProject do
 
   defp deps do
     [
-      {:igniter, "0.5.31"},
+      {:igniter, "~> 0.5 and >= 0.5.31"},
       {:guarded_struct, "~> 0.0.4"},
       {:igniter_js, "~> 0.4.6"},
       {:owl, "~> 0.12.2"},

--- a/priv/components/input_field.eex
+++ b/priv/components/input_field.eex
@@ -201,7 +201,8 @@ defmodule <%= @module %> do
   def error(assigns) do
     ~H"""
     <p class="mt-3 flex gap-3 text-sm leading-6 text-rose-600">
-      <.icon name="hero-exclamation-circle-mini" class="mt-0.5 h-5 w-5 flex-none" /> {render_slot(@inner_block)}
+      <.icon name="hero-exclamation-circle-mini" class="mt-0.5 h-5 w-5 flex-none" />
+      {render_slot(@inner_block)}
     </p>
     """
   end


### PR DESCRIPTION
This also removes calls to `Application.app_dir` that fail when this is being installed at the same time as the app is being created, i.e `mix igniter.new my_app --with phx.new --install mishka_chelekom`.