### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mishka-group/mishka_chelekom/security/code-scanning/1](https://github.com/mishka-group/mishka_chelekom/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow that restricts the `GITHUB_TOKEN` permissions to the minimal required for the workflow. Since none of the jobs shown require write access to the repository, specifying `permissions: contents: read` suffices.  
The best practice is to add this key at the root of the workflow file (before `jobs:`), ensuring all jobs inherit minimal privileges unless specifically overridden.  
Edit `.github/workflows/test.yml`, inserting the following block after the `name:` at the top:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
