### PR TITLE
Fix CSS typos, border logic, Gettext template bug, and swapped docs in 8 components

### DIFF
--- a/priv/components/banner.eex
+++ b/priv/components/banner.eex
@@ -371,7 +371,7 @@ defmodule <%= @module %> do
   defp border_class("large", "top", _), do: "border-b-4"
   defp border_class("extra_large", "top", _), do: "border-b-[5px]"
 
-  defp border_class("extra_small", "bottom", _), do: "border"
+  defp border_class("extra_small", "bottom", _), do: "border-b"
   defp border_class("small", "bottom", _), do: "border-b-2"
   defp border_class("medium", "bottom", _), do: "border-b-[3px]"
   defp border_class("large", "bottom", _), do: "border-b-4"

--- a/priv/components/blockquote.eex
+++ b/priv/components/blockquote.eex
@@ -249,7 +249,7 @@ defmodule <%= @module %> do
   defp border_class("small", position, _) do
     [
       position == "left" && "border-s-2",
-      position == "right" && "border-s-2",
+      position == "right" && "border-e-2",
       position == "full" && "border-2"
     ]
   end

--- a/priv/components/footer.eex
+++ b/priv/components/footer.eex
@@ -166,7 +166,7 @@ defmodule <%= @module %> do
   <% end %>
   defp space_class(params) when is_binary(params), do: params
 
-  defp maximum_width("extra_small"), do: "[&>div]:max-w-3xl	[&>div]:mx-auto"
+  defp maximum_width("extra_small"), do: "[&>div]:max-w-3xl [&>div]:mx-auto"
   defp maximum_width("small"), do: "[&>div]:max-w-4xl [&>div]:mx-auto"
   defp maximum_width("medium"), do: "[&>div]:max-w-5xl [&>div]:mx-auto"
   defp maximum_width("large"), do: "[&>div]:max-w-6xl [&>div]:mx-auto"

--- a/priv/components/gallery.eex
+++ b/priv/components/gallery.eex
@@ -56,9 +56,9 @@ defmodule <%= @module %> do
   attr :type, :string, values: ["default", "masonry", "featured"], default: "default", doc: ""
   attr :class, :any, default: nil, doc: "Custom CSS class for additional styling"
   attr :cols, :string, default: "", doc: "Determines cols of elements"
-  attr :gap, :string, default: "", doc: "Determines animation type for gallery items"
-  attr :animation, :string, default: "", doc: "Determines animation intensity/size"
-  attr :animation_size, :string, default: "extra_small", doc: "Determines gap between elements"
+  attr :gap, :string, default: "", doc: "Determines gap between elements"
+  attr :animation, :string, default: "", doc: "Determines animation type for gallery items"
+  attr :animation_size, :string, default: "extra_small", doc: "Determines animation intensity/size"
 
   attr :rest, :global,
     doc:

--- a/priv/components/overlay.eex
+++ b/priv/components/overlay.eex
@@ -94,7 +94,7 @@ defmodule <%= @module %> do
   <% end %>
   <%= if is_nil(@color) or "natural" in @color do %>
   defp color_class("natural") do
-    ["bg-natural-light[var(--overlay-opacity)]dark:bg-natural-dark/[var(--overlay-opacity)]"]
+    ["bg-natural-light/[var(--overlay-opacity)] dark:bg-natural-dark/[var(--overlay-opacity)]"]
   end
   <% end %>
   <%= if is_nil(@color) or "primary" in @color do %>

--- a/priv/components/password_field.eex
+++ b/priv/components/password_field.eex
@@ -1167,7 +1167,7 @@ defmodule <%= @module %> do
     if count = opts[:count] do
       Gettext.dngettext(<%= inspect(@web_module) %>.Gettext, "errors", msg, msg, count, opts)
     else
-      Gettext.dgettext(<%= @module %>.Gettext, "errors", msg, opts)
+      Gettext.dgettext(<%= inspect(@web_module) %>.Gettext, "errors", msg, opts)
     end
   end
 end

--- a/priv/components/radio_card.eex
+++ b/priv/components/radio_card.eex
@@ -874,7 +874,7 @@ defmodule <%= @module %> do
       "text-info-bordered-text-light border-info-bordered-text-light bg-info-bordered-bg-light",
       "dark:text-info-hover-dark dark:border-info-hover-dark dark:bg-info-bordered-bg-dark",
       "[&_.radio-card-input]:checked:accent-info-bordered-text-light",
-      "dark:[&_.radio-card-input]:checked:accent-info--bordered-text-dark",
+      "dark:[&_.radio-card-input]:checked:accent-info-bordered-text-dark",
       "[&_.radio-card-input]:border-info-bordered-text-light dark:[&_.radio-card-input]:border-info-bordered-text-dark",
       "has-[:checked]:border-info-indicator-alt-light dark:has-[:checked]:border-info-indicator-dark",
       "has-[:checked]:bg-[var(--color-info-gradient-indicator-dark)] dark:has-[:checked]:bg-info-indicator-alt-light"

--- a/priv/components/tooltip.eex
+++ b/priv/components/tooltip.eex
@@ -547,7 +547,7 @@ import Phoenix.LiveView.Utils, only: [random_id: 0]
   defp color_variant("bordered", "natural") do
     [
       "text-natural-bordered-text-light border-natural-bordered-text-light bg-natural-bordered-bg-light",
-      "dark:text-natural-bordered-text-dark dark:border-natural--bordered-text-dark dark:bg-natural-bordered-bg-dark"
+      "dark:text-natural-bordered-text-dark dark:border-natural-bordered-text-dark dark:bg-natural-bordered-bg-dark"
     ]
   end
   <% end %>


### PR DESCRIPTION
## Summary

Fixes 8 defects found across component templates in `priv/components/`. All are small, targeted corrections — no behavioral or structural changes.

### Fixes

1. **overlay.eex** — Missing `/` and space in Tailwind opacity class for natural color. Other colors (primary, secondary, etc.) are correct; only natural was affected.
   - `bg-natural-light[var(--overlay-opacity)]dark:` → `bg-natural-light/[var(--overlay-opacity)] dark:`

2. **tooltip.eex** — Double hyphen typo in bordered natural dark border class.
   - `dark:border-natural--bordered-text-dark` → `dark:border-natural-bordered-text-dark`

3. **radio_card.eex** — Double hyphen typo in bordered info dark accent class.
   - `accent-info--bordered-text-dark` → `accent-info-bordered-text-dark`

4. **blockquote.eex** — Wrong border direction for `"small"` + `"right"` position. Uses start border (`border-s-2`) instead of end border. All other sizes correctly use `border-e-*` for right.
   - `position == "right" && "border-s-2"` → `position == "right" && "border-e-2"`

5. **banner.eex** — `border_class("extra_small", "bottom", _)` returns `"border"` (all sides) instead of `"border-b"` (bottom only). All other bottom sizes use `border-b-*`.
   - `"border"` → `"border-b"`

6. **password_field.eex** — `translate_error/1` uses `<%= @module %>.Gettext` in the `else` branch, which expands to the component module (e.g., `MyAppWeb.Components.PasswordField.Gettext`) — a module that doesn't exist. The `if` branch correctly uses `<%= inspect(@web_module) %>.Gettext`.
   - `<%= @module %>.Gettext` → `<%= inspect(@web_module) %>.Gettext`

7. **footer.eex** — Tab character (`\t`) instead of space between CSS classes in `maximum_width("extra_small")`. All other sizes use spaces.

8. **gallery.eex** — Doc strings for `gap`, `animation`, and `animation_size` attrs are cyclically swapped in the first component. The second component (`gallery_media`, lines 155-160) already has the correct docs.

## Test plan

- [ ] Verify overlay natural color renders with correct opacity
- [ ] Verify tooltip and radio_card bordered variants apply correct dark mode styles
- [ ] Verify blockquote right border appears on the right side at small size
- [ ] Verify banner extra_small bottom border only appears on bottom
- [ ] Verify password_field validation errors render correctly (Gettext module resolves)
- [ ] Verify footer extra_small max-width classes apply correctly
- [ ] Verify gallery component docs match attribute purposes

