### PR TITLE
Add missing :if={@label} nil guards to floating labels and form fields

### DIFF
--- a/priv/components/date_time_field.eex
+++ b/priv/components/date_time_field.eex
@@ -204,6 +204,7 @@ defmodule <%= @module %> do
           />
 
           <label
+            :if={@label}
             class={[
               "floating-label px-1 start-1 -z-[1] absolute text-xs duration-300 transform scale-75 origin-[0]",
               variant_label_position(@floating),

--- a/priv/components/email_field.eex
+++ b/priv/components/email_field.eex
@@ -177,6 +177,7 @@ defmodule <%= @module %>  do
           />
 
           <label
+            :if={@label}
             class={[
               "floating-label px-1 start-1 -z-[1] absolute text-xs duration-300 transform scale-75 origin-[0]",
               variant_label_position(@floating),

--- a/priv/components/file_field.eex
+++ b/priv/components/file_field.eex
@@ -285,7 +285,7 @@ defmodule <%= @module %> do
       space_class(@space),
       @class
     ]}>
-      <.label for={@id}>{@label}</.label>
+      <.label :if={@label} for={@id}>{@label}</.label>
 
       <%%= if @live do %>
         <.live_file_input

--- a/priv/components/input_field.eex
+++ b/priv/components/input_field.eex
@@ -120,7 +120,7 @@ defmodule <%= @module %> do
   def <%= @component_prefix %>input(%{type: "select"} = assigns) do
     ~H"""
     <div>
-      <.label for={@id}>{@label}</.label>
+      <.label :if={@label} for={@id}>{@label}</.label>
 
       <select
         id={@id}
@@ -141,7 +141,7 @@ defmodule <%= @module %> do
   def <%= @component_prefix %>input(%{type: "textarea"} = assigns) do
     ~H"""
     <div>
-      <.label for={@id}>{@label}</.label>
+      <.label :if={@label} for={@id}>{@label}</.label>
       <textarea
         id={@id}
         name={@name}
@@ -161,7 +161,7 @@ defmodule <%= @module %> do
   def <%= @component_prefix %>input(assigns) do
     ~H"""
     <div>
-      <.label for={@id}>{@label}</.label>
+      <.label :if={@label} for={@id}>{@label}</.label>
 
       <input
         type={@type}

--- a/priv/components/number_field.eex
+++ b/priv/components/number_field.eex
@@ -173,6 +173,7 @@ defmodule <%= @module %> do
           />
 
           <label
+            :if={@label}
             class={[
               "floating-label px-1 start-1 -z-[1] absolute text-xs duration-300 transform scale-75 origin-[0]",
               variant_label_position(@floating),

--- a/priv/components/password_field.eex
+++ b/priv/components/password_field.eex
@@ -176,6 +176,7 @@ defmodule <%= @module %> do
           />
 
           <label
+            :if={@label}
             class={[
               "floating-label px-1 start-1 -z-[1] absolute text-xs duration-300 transform scale-75 origin-[0]",
               variant_label_position(@floating),

--- a/priv/components/range_field.eex
+++ b/priv/components/range_field.eex
@@ -116,7 +116,7 @@ defmodule <%= @module %> do
       width_class(@width),
       @class
     ]}>
-      <.label for={@id}>{@label}</.label>
+      <.label :if={@label} for={@id}>{@label}</.label>
       <div class="relative mb-8">
         <input type="range" value={@value} name={@name} id={@id} class={["w-full", color_class(@appearance, @color)]} {@rest} />
         <span
@@ -144,7 +144,7 @@ defmodule <%= @module %> do
       width_class(@width),
       @class
     ]}>
-      <.label for={@id}>{@label}</.label>
+      <.label :if={@label} for={@id}>{@label}</.label>
       <div class="relative mb-8">
         <input
           type="range"

--- a/priv/components/search_field.eex
+++ b/priv/components/search_field.eex
@@ -175,6 +175,7 @@ defmodule <%= @module %> do
           />
 
           <label
+            :if={@label}
             class={[
               "floating-label px-1 start-1 -z-[1] absolute text-xs duration-300 transform scale-75 origin-[0]",
               variant_label_position(@floating),

--- a/priv/components/tel_field.eex
+++ b/priv/components/tel_field.eex
@@ -178,6 +178,7 @@ defmodule <%= @module %> do
           />
 
           <label
+            :if={@label}
             class={[
               "floating-label px-1 start-1 -z-[1] absolute text-xs duration-300 transform scale-75 origin-[0]",
               variant_label_position(@floating),

--- a/priv/components/text_field.eex
+++ b/priv/components/text_field.eex
@@ -181,6 +181,7 @@ defmodule <%= @module %> do
           />
 
           <label
+            :if={@label}
             class={[
               "floating-label px-1 start-1 -z-[1] absolute text-xs duration-300 transform scale-75 origin-[0]",
               variant_label_position(@floating),

--- a/priv/components/textarea_field.eex
+++ b/priv/components/textarea_field.eex
@@ -168,6 +168,7 @@ defmodule <%= @module %> do
         >{Phoenix.HTML.Form.normalize_value("textarea", @value)}</textarea>
 
         <label
+          :if={@label}
           class={[
             "floating-label px-1 start-1 -z-[1] absolute text-xs duration-300 transform scale-75 origin-[0]",
             variant_label_position(@floating),

--- a/priv/components/url_field.eex
+++ b/priv/components/url_field.eex
@@ -165,6 +165,7 @@ defmodule <%= @module %> do
           />
 
           <label
+            :if={@label}
             class={[
               "floating-label px-1 start-1 -z-[1] absolute text-xs duration-300 transform scale-75 origin-[0]",
               variant_label_position(@floating),


### PR DESCRIPTION
## Summary

Adds `:if={@label}` nil guards to label elements that render `{@label}` unconditionally when `@label` defaults to nil.

### Floating label templates (9 components)

When `floating="inner"` or `floating="outer"` is used without providing a `label` attribute, the floating `<label>` element renders nil to the DOM. The non-floating templates in the same components already correctly use `:if={@label}` guards.

Affected: `text_field`, `email_field`, `password_field`, `number_field`, `tel_field`, `url_field`, `search_field`, `date_time_field`, `textarea_field`

### Unconditional label rendering (3 components)

These components render `<.label>` without checking if `@label` is nil, producing empty label elements in the DOM.

- `range_field` (2 occurrences — both template variants)
- `input_field` (3 occurrences — select, textarea, and generic input)
- `file_field` (1 occurrence)

## Test plan

- [ ] Use any form field with `floating="inner"` or `floating="outer"` without providing a `label` — should not render an empty `<label>` element
- [ ] Use range_field, input_field, or file_field without a `label` — should not render an empty `<label>` element
- [ ] Use all affected components WITH a label — should render normally (no regression)